### PR TITLE
Fix: Right click doesn't open popup context menu

### DIFF
--- a/simulator-ui/src/java/main/ca/nengo/ui/lib/world/handlers/MouseHandler.java
+++ b/simulator-ui/src/java/main/ca/nengo/ui/lib/world/handlers/MouseHandler.java
@@ -180,7 +180,7 @@ public class MouseHandler extends PBasicInputEventHandler {
 	public void mouseReleased(PInputEvent event) {
 		super.mouseReleased(event);
 
-		if (mousePressedIsPopupTrigger) {
+		if (mousePressedIsPopupTrigger || event.isPopupTrigger()) {
 			mousePressedIsPopupTrigger = false;
 			
 			// Check the mouse hasn't moved too far off from it's pressed position


### PR DESCRIPTION
I'm stuck on a Windows machine so it might be Windows-only.

I believe the regression was due to 682007f4, so @hunse can you review this? And it would be good to test this change on OS X or Linux.
