### PR TITLE
Modified quick and layout files so they are always in simulator-ui

### DIFF
--- a/simulator-ui/python/nef/nef_core.py
+++ b/simulator-ui/python/nef/nef_core.py
@@ -12,6 +12,7 @@ from ca.nengo.model import StructuralException
 from ca.nengo.io import FileManager
 import java
 import warnings
+import os
 
 from java.util import ArrayList
 from java.util import HashMap
@@ -160,6 +161,8 @@ class Network:
             quick=self.defaults['quick'] #load default quick value
             
         if quick:
+            parent = os.path.dirname(__file__)
+            parent = os.path.join(parent[:parent.index("python")], "quick")
             storage_name='quick_%s_%d_%d_%1.3f_%1.3f'%(storage_code,neurons,dimensions,tau_rc,tau_ref)
             if type(max_rate) is tuple and len(max_rate)==2:
                 storage_name+='_%1.1f_%1.1f'%max_rate
@@ -184,9 +187,8 @@ class Network:
             if seed is not None:
                 storage_name+='_seed%08x'%seed
             if not java.io.File(storage_name+'.'+FileManager.ENSEMBLE_EXTENSION).exists():
-                dir=java.io.File('quick')
-                if not dir.exists(): dir.mkdirs()
-                storage_name='quick'+java.io.File.separator+storage_name
+                if not java.io.File(parent).exists(): java.io.File(parent).mkdirs()
+                storage_name=os.path.join(parent, storage_name)
         else:
             storage_name=''
             

--- a/simulator-ui/python/timeview/components/timecontrol.py
+++ b/simulator-ui/python/timeview/components/timecontrol.py
@@ -7,6 +7,8 @@ from java.awt.event import *
 
 from ca.nengo.model import SimulationMode
 
+import os
+
 # for save_pdf
 import sys
 if 'lib/itextpdf-5.3.4.jar' not in sys.path:
@@ -18,9 +20,11 @@ class Icon:
 class ShadedIcon:
     pass
 
+parent = os.path.dirname(__file__)
+parent = parent[:parent.index("python")]
 for name in 'pause play configure end start backward forward restart arrowup arrowdown save restore refresh data pdf'.split():
-    setattr(Icon, name, ImageIcon('python/images/%s.png' % name))
-    setattr(ShadedIcon, name, ImageIcon('python/images/%s-pressed.png' % name))
+    setattr(Icon, name, ImageIcon(parent + ('python/images/%s.png' % name)))
+    setattr(ShadedIcon, name, ImageIcon(parent + ('python/images/%s-pressed.png' % name)))
 
 class TimeControl(JPanel, ChangeListener, ActionListener):
     def __init__(self, view):

--- a/simulator/src/java/main/ca/nengo/io/FileManager.java
+++ b/simulator/src/java/main/ca/nengo/io/FileManager.java
@@ -60,25 +60,6 @@ public class FileManager {
 	 */
 	public static final String ENSEMBLE_EXTENSION = "nef";
 
-	private static File ourDefaultLocation = new File("./work");
-	static {
-		ourDefaultLocation.mkdirs();
-	}
-
-	/**
-	 * @return Default location for saving files
-	 */
-	public static File getDefaultLocation() {
-		return ourDefaultLocation;
-	}
-
-	/**
-	 * @param location Default location for saving files
-	 */
-	public static void setDefaultLocation(File location) {
-		ourDefaultLocation = location;
-	}
-
 	/**
 	 * @param node Node to serialize
 	 * @param destination File to save serialized Node in


### PR DESCRIPTION
I changed various places throughout the code so that files would always be stored in the simulator-ui folder (mainly this impacts the quick and layout files).  Previously these files would be stored relative to the working directory.  When running scripts through Nengo the working dir is simulator-ui, so everything worked fine.  But when running a script by itself (e.g. from command line/eclipse), it would create "quick" and "layout" folders wherever that script was run from.

I think the desired behaviour is just to have all these files in the same place, regardless of how the script is run.  However, it's possible that people like to have separate "quick" and "layout" folders, which is why I'm making this pull request.  So speak up if you don't want this changed!
