### PR TITLE
Added interactive components to display arbitrary images

### DIFF
--- a/simulator-ui/python/timeview/components/__init__.py
+++ b/simulator-ui/python/timeview/components/__init__.py
@@ -24,3 +24,4 @@ from hrrgraph import HRRGraph
 from text_list import TextList
 from colorgrid import ColorGrid
 from boxes import Boxes
+from drawimage import DrawImage

--- a/simulator-ui/python/timeview/components/drawimage.py
+++ b/simulator-ui/python/timeview/components/drawimage.py
@@ -1,0 +1,32 @@
+from javax.swing import *
+from javax.swing.event import *
+from java.awt import *
+from java.awt.event import *
+
+import core
+
+class DrawImage(core.DataViewComponent):
+    def __init__(self, view, name, func, args=(), label=None):
+        core.DataViewComponent.__init__(self, label)
+        self.view = view
+        self.name = name
+        self.func = func
+        self.args = args
+        self.data = self.view.watcher.watch(name, func, args=args)
+        self.margin = 0
+        self.setSize(200, 200)
+        self.image = None
+        
+    def tick(self, t):
+        try:
+            self.image = self.data.get(start=self.view.current_tick, count=1)[0][0]
+        except Exception,e:
+            print "error in get",e
+            return
+                       
+    def paintComponent(self, g):
+        core.DataViewComponent.paintComponent(self, g)
+
+        if self.image is not None:
+            g.drawImage(self.image, 0, 0, self.size.width, self.size.height,
+                        0, 0, self.image.getWidth(), self.image.getHeight(), None)

--- a/simulator-ui/python/timeview/watches/imagewatch.py
+++ b/simulator-ui/python/timeview/watches/imagewatch.py
@@ -1,0 +1,13 @@
+from timeview.watches.watchtemplate import WatchTemplate
+from timeview import components
+
+class ImageWatch(WatchTemplate):
+    def check(self, obj):
+        return hasattr(obj, "get_image")
+    
+    def display_image(self, obj):
+        return [obj.get_image()]
+        
+    def views(self, obj):
+        r = [("display image", components.DrawImage, dict(func=self.display_image, label=obj.name))]
+        return r


### PR DESCRIPTION
Makes it easy to attach custom displays to objects.  All the object has to do is define a `get_image` function that returns a Java `Image` object.

Ready for review/merging :cake: 
