### PR TITLE
Fix for occasional crash due to data updating

### DIFF
--- a/simulator-ui/python/timeview/javaviz.py
+++ b/simulator-ui/python/timeview/javaviz.py
@@ -42,11 +42,11 @@ class ProbeNode(nef.Node):
         try:
             if len(self.data) > 0 and self.data[0][1] > time:
                 del self.data[:]
-        except IndexError:
+            self.data.append((id, time, data))
+        except IndexError, IndexOutOfBoundsException:
             # this can happen (rarely) due to threads updating
             # at unlucky times
             pass
-        self.data.append((id, time, data))
 
     def run(self, start, end):
         for p in self.probes.values():


### PR DESCRIPTION
Javaviz will randomly crash every once in a while, if data happens to get updated during this function.  I just followed the previous solution of ignoring the error, since we'll be getting plenty more data.
