### PR TITLE
Remove most uses of import *

### DIFF
--- a/simulator-ui/python/code_generator.py
+++ b/simulator-ui/python/code_generator.py
@@ -8,17 +8,17 @@ def generate(network):
         if hasattr(node,'getEnsembleFactory'):
             nf=node.getEnsembleFactory().getNodeFactory()
             c="net.make('%s',neurons=%d,dimensions=%d,tau_rc=%g,tau_ref=%g,intercept=(%g,%g),max_rate=(%g,%g))"%(node.name,node.neurons,node.dimension,nf.tauRC,nf.tauRef,nf.intercept.low,nf.intercept.high,nf.maxRate.low,nf.maxRate.high)
-            code.append(c)    
-    
-    importable=['sin','cos','tan','asin','acos','atan','exp','log','pow','sqrt']        
-            
-    imported_funcs=[]        
+            code.append(c)
+
+    importable=['sin','cos','tan','asin','acos','atan','exp','log','pow','sqrt']
+
+    imported_funcs=[]
     for p in network.projections:
         origin=p.origin
-        termination=p.termination  
-        
+        termination=p.termination
+
         connect="'%s','%s'"%(origin.node.name,termination.node.name)
-        
+
         if origin.name!='X':
             funcs=[]
             for f in origin.functions:
@@ -27,7 +27,7 @@ def generate(network):
                     exp=exp.replace('^','**')
                     exp=exp.replace('!',' not ')
                     exp=exp.replace('&',' and ')
-                    exp=exp.replace('|',' or ')                    
+                    exp=exp.replace('|',' or ')
                     exp=exp.replace('ln','log')
                     for f in importable:
                         if f in exp and not f in imported_funcs:
@@ -39,58 +39,50 @@ def generate(network):
                     funcs.append('0')
             code.append('def function(x):')
             code.append('    return [%s]'%(','.join(funcs)))
-            connect=connect+',func=function,origin_name="%s"'%origin.name                
-        
-        
+            connect=connect+',func=function,origin_name="%s"'%origin.name
+
+
         tr='['+','.join(['['+','.join(['%g'%x for x in row])+']' for row in termination.transform])+']'
-        
+
         connect+=',transform=%s'%tr
         # TODO: look for special cases of identify matrixes (and maybe weight, index_pre, and index post?)
-        
+
         code.append('net.connect(%s,pstc=%g)'%(connect,termination.tau))
     if len(imported_funcs)>0:
         code[1:1]=['from math import %s'%','.join(imported_funcs)]
     return '\n'.join(code)
-    
-    
-    
-    
-import java
-import javax
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
+
+
+from javax.swing import JFrame, JScrollPane, JTextArea, JViewport
+from java.awt import BorderLayout
 import ca.nengo
-    
+
 class CodeView(ca.nengo.util.VisiblyMutable.Listener):
     def __init__(self,network):
         self.network=network
         self.frame=JFrame(network.name)
         self.frame.visible=True
         self.frame.layout=BorderLayout()
-        self.frame.size=(800,600)        
-        
-        
+        self.frame.size=(800,600)
+
+
         self.code=JTextArea(generate(self.network),editable=False)
         scroll=JScrollPane(self.code)
         scroll.viewport.scrollMode=JViewport.SIMPLE_SCROLL_MODE   # not sure why this is needed -- if not done, text is corrupted when scrolling
         self.frame.add(scroll)
-        
+
         self.network.addChangeListener(self)
-        
+
     def changed(self,event):
         self.code.text=generate(self.network)
-        
-        
-        
-"""        
-import nef
-net=nef.Network("GenTest")
-net.make('A',neurons=100,dimensions=2,tau_rc=0.02,tau_ref=0.002,intercept=(-1,1),max_rate=(200,400))
-net.make('B',neurons=100,dimensions=2,tau_rc=0.02,tau_ref=0.002,intercept=(-1,1),max_rate=(30,60))
-net.connect('A','B',transform=[[1,0],[0,1]],pstc=0.01)        
 
-net.add_to_nengo()
-CodeView(net.network)
-"""
+
+if __name__ == '__main__':
+    import nef
+    net=nef.Network("GenTest")
+    net.make('A',neurons=100,dimensions=2,tau_rc=0.02,tau_ref=0.002,intercept=(-1,1),max_rate=(200,400))
+    net.make('B',neurons=100,dimensions=2,tau_rc=0.02,tau_ref=0.002,intercept=(-1,1),max_rate=(30,60))
+    net.connect('A','B',transform=[[1,0],[0,1]],pstc=0.01)
+
+    net.add_to_nengo()
+    CodeView(net.network)

--- a/simulator-ui/python/nef/templates/linear_system.py
+++ b/simulator-ui/python/nef/templates/linear_system.py
@@ -2,19 +2,19 @@ title='General Linear System'
 label='Linear\nSystem'
 icon='linearsystem.png'
 
-from ca.nengo.ui.configurable import *
+from ca.nengo.ui.configurable import Property, PropertyInputPanel
 from ca.nengo.ui.configurable.managers import ConfigManager
 from ca.nengo.ui.configurable.descriptors import PCouplingMatrix
 from ca.nengo.util import MU
 from ca.nengo.ui.lib.util import UserMessages
 
-from javax.swing import *
+from javax.swing import JButton, JDialog, JLabel, JTextField
 from javax.swing.event import DocumentListener
 
 class SystemMatrixInputPanel(PropertyInputPanel,DocumentListener):
     def __init__(self,property):
         PropertyInputPanel.__init__(self,property)
-        self.add(JLabel("State dimension: "))    
+        self.add(JLabel("State dimension: "))
         self.state_dim=JTextField(10)
         self.state_dim.document.addDocumentListener(self)
         self.add(self.state_dim)
@@ -44,7 +44,7 @@ class SystemMatrixInputPanel(PropertyInputPanel,DocumentListener):
                 self.matrix=None
         except:
             self.matrix=None
-        
+
     def isValueSet(self):
         return self.matrix is not None
     def getValue(self):
@@ -59,7 +59,7 @@ class SystemMatrixInputPanel(PropertyInputPanel,DocumentListener):
         self.change_dim(event)
     def removeUpdate(self,event):
         self.change_dim(event)
-    
+
 class PSystemMatrix(Property):
     matrix=None
     def createInputPanel(self):
@@ -68,7 +68,7 @@ class PSystemMatrix(Property):
         return "System Matrix"
     def getTypeClass(self):
         return PCouplingMatrix(1,1).getTypeClass()
-        
+
 description="""<html>This is a generic template for constructing a recurrent network that implements the specified dynamic linear system: dx/dt = Ax + Bu. Input Bu must be supplied after construction by adding a termination with the B matrix.</html>"""
 
 params=[
@@ -94,7 +94,7 @@ def make(net,name='System',neurons=100,A=[[0]],tau_feedback=0.1):
     A=numeric.array(A)
     assert len(A.shape)==2
     assert A.shape[0]==A.shape[1]
-    
+
     dimensions=A.shape[0]
     state=net.make(name,neurons,dimensions)
     Ap=A*tau_feedback+numeric.identity(dimensions)
@@ -121,4 +121,3 @@ def make(net,name='System',neurons=100,A=[[0]],tau_feedback=0.1):
         net.network.setMetaData("templateProjections", HashMap())
     templateproj = net.network.getMetaData("templateProjections")
     templateproj.put(name, name)
-    

--- a/simulator-ui/python/nef/templates/networkarray.py
+++ b/simulator-ui/python/nef/templates/networkarray.py
@@ -1,6 +1,6 @@
 import nef
-from ca.nengo.ui.configurable import *
-from javax.swing import *
+from ca.nengo.ui.configurable import Property, PropertyInputPanel
+from javax.swing import JComboBox
 from javax.swing.event import DocumentListener
 
 title='Network Array'
@@ -11,8 +11,8 @@ class SignInputPanel(PropertyInputPanel,DocumentListener):
     def __init__(self,property):
         PropertyInputPanel.__init__(self,property)
         self.comboBox = JComboBox(["Unconstrained", "Positive", "Negative"])
-        self.add(self.comboBox)    
-        
+        self.add(self.comboBox)
+
     def isValueSet(self):
         return True
     def getValue(self):
@@ -24,7 +24,7 @@ class SignInputPanel(PropertyInputPanel,DocumentListener):
         else:
             return 0
     def setValue(self, value):
-        pass 
+        pass
 
 class PTemplateSign(Property):
     def createInputPanel(self):
@@ -33,7 +33,7 @@ class PTemplateSign(Property):
         return "Encoder Sign"
     def getTypeClass(self):
         return PInt
-    
+
 description="""<html>This template enables constructing subnetworks full D (# of dimensions) independent populations of neurons.  These are faster to construct but cannot compute all the same nonlinear functions as a single large population with D dimensions.</html>"""
 
 params=[

--- a/simulator-ui/python/space.py
+++ b/simulator-ui/python/space.py
@@ -1,468 +1,550 @@
 from __future__ import generators
 
 import sys
-for p in ['python/jar/jpct.jar','python/jar/jbullet.jar','python/jar/vecmath.jar']:
+for p in ('python/jar/jpct.jar',
+          'python/jar/jbullet.jar',
+          'python/jar/vecmath.jar'):
     if p not in sys.path:
         sys.path.append(p)
 
 import java
-from javax.swing import *
-from javax.swing import JComponent
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
-from com.threed.jpct import *
-from com.threed.jpct.util import *
-
-from com.bulletphysics.collision.broadphase import *
-from com.bulletphysics.collision.dispatch import *
-from com.bulletphysics.collision.shapes import *
-from com.bulletphysics.dynamics import *
-from com.bulletphysics.dynamics.constraintsolver import *
-from com.bulletphysics.dynamics.vehicle import *
-from com.bulletphysics.linearmath import *
+from java.awt import Color
+from java.awt.event import KeyEvent
+from javax.swing import JComponent, JFrame
 from javax.vecmath import Vector3f, Matrix4f
+import math
+
+from com.threed.jpct import (
+    FrameBuffer, Loader, Matrix, Object3D, Primitives, SimpleVector, Texture,
+    TextureManager, World)
+
+from com.bulletphysics.collision.broadphase import AxisSweep3
+from com.bulletphysics.collision.dispatch import (
+    CollisionDispatcher, CollisionObject, CollisionWorld,
+    DefaultCollisionConfiguration)
+from com.bulletphysics.collision.shapes import BoxShape, StaticPlaneShape
+from com.bulletphysics.dynamics import (
+    DiscreteDynamicsWorld, RigidBody, RigidBodyConstructionInfo)
+from com.bulletphysics.dynamics.constraintsolver import (
+    SequentialImpulseConstraintSolver)
+from com.bulletphysics.dynamics.vehicle import (
+    DefaultVehicleRaycaster, RaycastVehicle, VehicleTuning)
+from com.bulletphysics.linearmath import DefaultMotionState, Transform
 
 import ccm
 
 
 def createBox(x, y, z):
-    box=Object3D(12)
-    box.addTriangle(SimpleVector(x, y, -z), SimpleVector(x, -y, -z), SimpleVector(-x, y, -z))
-    box.addTriangle(SimpleVector(-x, -y, -z), SimpleVector(-x, y, -z), SimpleVector(x, -y, -z))
+    box = Object3D(12)
+    box.addTriangle(SimpleVector(x, y, -z),
+                    SimpleVector(x, -y, -z),
+                    SimpleVector(-x, y, -z))
+    box.addTriangle(SimpleVector(-x, -y, -z),
+                    SimpleVector(-x, y, -z),
+                    SimpleVector(x, -y, -z))
 
-    box.addTriangle(SimpleVector(x, y, z), SimpleVector(-x, y, z), SimpleVector(x, -y, z))
-    box.addTriangle(SimpleVector(-x, -y, z), SimpleVector(x, -y, z), SimpleVector(-x, y, z))
+    box.addTriangle(SimpleVector(x, y, z),
+                    SimpleVector(-x, y, z),
+                    SimpleVector(x, -y, z))
+    box.addTriangle(SimpleVector(-x, -y, z),
+                    SimpleVector(x, -y, z),
+                    SimpleVector(-x, y, z))
 
-    box.addTriangle(SimpleVector(x, -y, -z), SimpleVector(x, y, -z), SimpleVector(x, -y, z))
-    box.addTriangle(SimpleVector(x, y, z), SimpleVector(x, -y, z), SimpleVector(x, y, -z))
+    box.addTriangle(SimpleVector(x, -y, -z),
+                    SimpleVector(x, y, -z),
+                    SimpleVector(x, -y, z))
+    box.addTriangle(SimpleVector(x, y, z),
+                    SimpleVector(x, -y, z),
+                    SimpleVector(x, y, -z))
 
-    box.addTriangle(SimpleVector(-x, y, z), SimpleVector(-x, y, -z), SimpleVector(-x, -y, z))
-    box.addTriangle(SimpleVector(-x, -y, -z), SimpleVector(-x, -y, z), SimpleVector(-x, y, -z))
+    box.addTriangle(SimpleVector(-x, y, z),
+                    SimpleVector(-x, y, -z),
+                    SimpleVector(-x, -y, z))
+    box.addTriangle(SimpleVector(-x, -y, -z),
+                    SimpleVector(-x, -y, z),
+                    SimpleVector(-x, y, -z))
 
-    box.addTriangle(SimpleVector(-x, -y, -z), SimpleVector(x, -y, -z), SimpleVector(-x, -y, z))
-    box.addTriangle(SimpleVector(x, -y, z), SimpleVector(-x, -y, z), SimpleVector(x, -y, -z))
+    box.addTriangle(SimpleVector(-x, -y, -z),
+                    SimpleVector(x, -y, -z),
+                    SimpleVector(-x, -y, z))
+    box.addTriangle(SimpleVector(x, -y, z),
+                    SimpleVector(-x, -y, z),
+                    SimpleVector(x, -y, -z))
 
-    box.addTriangle(SimpleVector(x, y, z), SimpleVector(x, y, -z), SimpleVector(-x, y, z))
-    box.addTriangle(SimpleVector(-x, y, -z), SimpleVector(-x, y, z), SimpleVector(x, y, -z))
+    box.addTriangle(SimpleVector(x, y, z),
+                    SimpleVector(x, y, -z),
+                    SimpleVector(-x, y, z))
+    box.addTriangle(SimpleVector(-x, y, -z),
+                    SimpleVector(-x, y, z),
+                    SimpleVector(x, y, -z))
 
     return box
 
-def createBoxPieces(x,y,z):
-    pieces=[]
-    box=Object3D(12)
-    box.addTriangle(SimpleVector(x, y, -z), SimpleVector(x, -y, -z), SimpleVector(-x, y, -z))
-    box.addTriangle(SimpleVector(-x, -y, -z), SimpleVector(-x, y, -z), SimpleVector(x, -y, -z))
+
+def createBoxPieces(x, y, z):
+    pieces = []
+    box = Object3D(12)
+    box.addTriangle(SimpleVector(x, y, -z),
+                    SimpleVector(x, -y, -z),
+                    SimpleVector(-x, y, -z))
+    box.addTriangle(SimpleVector(-x, -y, -z),
+                    SimpleVector(-x, y, -z),
+                    SimpleVector(x, -y, -z))
     pieces.append(box)
 
-    box=Object3D(12)
-    box.addTriangle(SimpleVector(x, y, z), SimpleVector(-x, y, z), SimpleVector(x, -y, z))
-    box.addTriangle(SimpleVector(-x, -y, z), SimpleVector(x, -y, z), SimpleVector(-x, y, z))
+    box = Object3D(12)
+    box.addTriangle(SimpleVector(x, y, z),
+                    SimpleVector(-x, y, z),
+                    SimpleVector(x, -y, z))
+    box.addTriangle(SimpleVector(-x, -y, z),
+                    SimpleVector(x, -y, z),
+                    SimpleVector(-x, y, z))
     pieces.append(box)
 
-    box=Object3D(12)
-    box.addTriangle(SimpleVector(x, -y, -z), SimpleVector(x, y, -z), SimpleVector(x, -y, z))
-    box.addTriangle(SimpleVector(x, y, z), SimpleVector(x, -y, z), SimpleVector(x, y, -z))
+    box = Object3D(12)
+    box.addTriangle(SimpleVector(x, -y, -z),
+                    SimpleVector(x, y, -z),
+                    SimpleVector(x, -y, z))
+    box.addTriangle(SimpleVector(x, y, z),
+                    SimpleVector(x, -y, z),
+                    SimpleVector(x, y, -z))
     pieces.append(box)
 
-    box=Object3D(12)
-    box.addTriangle(SimpleVector(-x, y, z), SimpleVector(-x, y, -z), SimpleVector(-x, -y, z))
-    box.addTriangle(SimpleVector(-x, -y, -z), SimpleVector(-x, -y, z), SimpleVector(-x, y, -z))
+    box = Object3D(12)
+    box.addTriangle(SimpleVector(-x, y, z),
+                    SimpleVector(-x, y, -z),
+                    SimpleVector(-x, -y, z))
+    box.addTriangle(SimpleVector(-x, -y, -z),
+                    SimpleVector(-x, -y, z),
+                    SimpleVector(-x, y, -z))
     pieces.append(box)
 
-    box=Object3D(12)
-    box.addTriangle(SimpleVector(-x, -y, -z), SimpleVector(x, -y, -z), SimpleVector(-x, -y, z))
-    box.addTriangle(SimpleVector(x, -y, z), SimpleVector(-x, -y, z), SimpleVector(x, -y, -z))
+    box = Object3D(12)
+    box.addTriangle(SimpleVector(-x, -y, -z),
+                    SimpleVector(x, -y, -z),
+                    SimpleVector(-x, -y, z))
+    box.addTriangle(SimpleVector(x, -y, z),
+                    SimpleVector(-x, -y, z),
+                    SimpleVector(x, -y, -z))
     pieces.append(box)
 
-    box=Object3D(12)
-    box.addTriangle(SimpleVector(x, y, z), SimpleVector(x, y, -z), SimpleVector(-x, y, z))
-    box.addTriangle(SimpleVector(-x, y, -z), SimpleVector(-x, y, z), SimpleVector(x, y, -z))
+    box = Object3D(12)
+    box.addTriangle(SimpleVector(x, y, z),
+                    SimpleVector(x, y, -z),
+                    SimpleVector(-x, y, z))
+    box.addTriangle(SimpleVector(-x, y, -z),
+                    SimpleVector(-x, y, z),
+                    SimpleVector(x, y, -z))
     pieces.append(box)
 
     return pieces
 
 
-
 class Room(ccm.Model):
-    def __init__(self, x, y, z=1,gravity=10,color=[Color(0xFFFFFF),Color(0xFFFFFF),Color(0xEEEEEE),Color(0xDDDDDD),Color(0xCCCCCC),Color(0xBBBBBB)],camera=(0,0,10),dt=0.0001):
+    def __init__(self, x, y, z=1, gravity=10, color=[
+            Color(0xFFFFFF), Color(0xFFFFFF), Color(0xEEEEEE), Color(0xDDDDDD),
+            Color(0xCCCCCC), Color(0xBBBBBB)], camera=(0, 0, 10), dt=0.0001):
         ccm.Model.__init__(self)
-        self.size=(x, y, z)
-        self.world=World()
-        self.dt=dt
-        brightness=180
+        self.size = (x, y, z)
+        self.world = World()
+        self.dt = dt
+        brightness = 180
         self.world.setAmbientLight(brightness, brightness, brightness)
-        self.world.addLight(SimpleVector(2, 2, 5), 10,10,10)
+        self.world.addLight(SimpleVector(2, 2, 5), 10, 10, 10)
         self.world.camera.setPosition(*camera)
-        self.world.camera.setOrientation(SimpleVector(0,0,-1),SimpleVector(0,-1,0))
+        self.world.camera.setOrientation(
+            SimpleVector(0, 0, -1), SimpleVector(0, -1, 0))
 
-        self.objects=[]
+        self.objects = []
 
-        collisionConfiguration=DefaultCollisionConfiguration()
-        dispatcher=CollisionDispatcher(collisionConfiguration)
+        collisionConfiguration = DefaultCollisionConfiguration()
+        dispatcher = CollisionDispatcher(collisionConfiguration)
 
-        overlappingPairCache=AxisSweep3(Vector3f(-x/2.0, -y/2.0, -z/2.0), Vector3f(x/2.0,y/2.0,z/2.0), 1024)
-        solver=SequentialImpulseConstraintSolver()
-        self.physics=DiscreteDynamicsWorld(dispatcher, overlappingPairCache, solver, collisionConfiguration)
+        overlappingPairCache = AxisSweep3(
+            Vector3f(-x / 2.0, -y / 2.0, -z / 2.0),
+            Vector3f(x / 2.0, y / 2.0, z / 2.0),
+            1024)
+        solver = SequentialImpulseConstraintSolver()
+        self.physics = DiscreteDynamicsWorld(
+            dispatcher, overlappingPairCache, solver, collisionConfiguration)
         self.physics.setGravity(Vector3f(0, 0, -gravity))
 
-        t=Transform()
+        t = Transform()
         t.setIdentity()
-        rbi=RigidBodyConstructionInfo(0,DefaultMotionState(t),StaticPlaneShape(Vector3f(0,0,1),0),Vector3f(0,0,0))
+        rbi = RigidBodyConstructionInfo(
+            0, DefaultMotionState(t), StaticPlaneShape(
+                Vector3f(0, 0, 1), 0), Vector3f(0, 0, 0))
         self.physics.addRigidBody(RigidBody(rbi))
-        rbi=RigidBodyConstructionInfo(0,DefaultMotionState(t),StaticPlaneShape(Vector3f(0,1,0),-y/2.0),Vector3f(0,0,0))
+        rbi = RigidBodyConstructionInfo(
+            0, DefaultMotionState(t), StaticPlaneShape(
+                Vector3f(0, 1, 0), -y / 2.0), Vector3f(0, 0, 0))
         self.physics.addRigidBody(RigidBody(rbi))
-        rbi=RigidBodyConstructionInfo(0,DefaultMotionState(t),StaticPlaneShape(Vector3f(0,-1,0),-y/2.0),Vector3f(0,0,0))
+        rbi = RigidBodyConstructionInfo(
+            0, DefaultMotionState(t), StaticPlaneShape(
+                Vector3f(0, -1, 0), -y / 2.0), Vector3f(0, 0, 0))
         self.physics.addRigidBody(RigidBody(rbi))
-        rbi=RigidBodyConstructionInfo(0,DefaultMotionState(t),StaticPlaneShape(Vector3f(1,0,0),-x/2.0),Vector3f(0,0,0))
+        rbi = RigidBodyConstructionInfo(
+            0, DefaultMotionState(t), StaticPlaneShape(
+                Vector3f(1, 0, 0), -x / 2.0), Vector3f(0, 0, 0))
         self.physics.addRigidBody(RigidBody(rbi))
-        rbi=RigidBodyConstructionInfo(0,DefaultMotionState(t),StaticPlaneShape(Vector3f(-1,0,0),-x/2.0),Vector3f(0,0,0))
+        rbi = RigidBodyConstructionInfo(
+            0, DefaultMotionState(t), StaticPlaneShape(
+                Vector3f(-1, 0, 0), -x / 2.0), Vector3f(0, 0, 0))
         self.physics.addRigidBody(RigidBody(rbi))
 
-        self.vehicle_raycaster=DefaultVehicleRaycaster(self.physics)
+        self.vehicle_raycaster = DefaultVehicleRaycaster(self.physics)
 
-        if not isinstance(color,(list,tuple)):
-            room=createBox(x/2.0, y/2.0, z/2.0)
-            room.translate(0, 0, z/2.0)
+        if not isinstance(color, (list, tuple)):
+            room = createBox(x / 2.0, y / 2.0, z / 2.0)
+            room.translate(0, 0, z / 2.0)
             room.invert()
-            colorname='room%d'%id(self)
-            TextureManager.getInstance().addTexture(colorname,Texture(1, 1, color))
+            colorname = 'room%d' % id(self)
+            TextureManager.getInstance().addTexture(
+                colorname, Texture(1, 1, color))
             room.setTexture(colorname)
-            room.shadingMode=Object3D.SHADING_FAKED_FLAT
+            room.shadingMode = Object3D.SHADING_FAKED_FLAT
             room.build()
             self.world.addObject(room)
         else:
-            room=createBoxPieces(x/2.0, y/2.0, z/2.0)
-            for i,r in enumerate(room):
-                r.translate(0, 0, z/2.0)
+            room = createBoxPieces(x / 2.0, y / 2.0, z / 2.0)
+            for i, r in enumerate(room):
+                r.translate(0, 0, z / 2.0)
                 r.invert()
-                colorname='room%d_%d'%(id(self),i)
-                TextureManager.getInstance().addTexture(colorname,Texture(1, 1, color[i%len(color)]))
+                colorname = 'room%d_%d' % (id(self), i)
+                TextureManager.getInstance().addTexture(
+                    colorname, Texture(1, 1, color[i % len(color)]))
                 r.setTexture(colorname)
-                r.shadingMode=Object3D.SHADING_FAKED_FLAT
+                r.shadingMode = Object3D.SHADING_FAKED_FLAT
                 r.build()
                 self.world.addObject(r)
 
-        self.ratelimit=RateLimit()
+        self.ratelimit = RateLimit()
 
-    def add(self, obj, x,y,z=None):
+    def add(self, obj, x, y, z=None):
         if z is None:
-            t=Transform()
-            min=Vector3f()
-            max=Vector3f()
-            obj.physics.getAabb(min,max)
-            z=-min.z
-        self.temp=obj
-        if hasattr(obj,'physics'):
-            t=Transform()
-            ms=obj.physics.motionState
+            t = Transform()
+            min = Vector3f()
+            max = Vector3f()
+            obj.physics.getAabb(min, max)
+            z = -min.z
+        self.temp = obj
+        if hasattr(obj, 'physics'):
+            t = Transform()
+            ms = obj.physics.motionState
             ms.getWorldTransform(t)
-            m=Matrix4f()
+            m = Matrix4f()
             t.getMatrix(m)
-            m.m03=x
-            m.m13=y
-            m.m23=z
+            m.m03 = x
+            m.m13 = y
+            m.m23 = z
             t.set(m)
-            ms.worldTransform=t
-            obj.physics.motionState=ms
+            ms.worldTransform = t
+            obj.physics.motionState = ms
 
             self.physics.addRigidBody(obj.physics)
 
-            if hasattr(obj,'wheels'):
-                tuning=VehicleTuning()
-                obj.vehicle=RaycastVehicle(tuning,obj.physics,self.vehicle_raycaster)
-                obj.physics.setActivationState(CollisionObject.DISABLE_DEACTIVATION)
+            if hasattr(obj, 'wheels'):
+                tuning = VehicleTuning()
+                obj.vehicle = RaycastVehicle(
+                    tuning, obj.physics, self.vehicle_raycaster)
+                obj.physics.setActivationState(
+                    CollisionObject.DISABLE_DEACTIVATION)
                 self.physics.addVehicle(obj.vehicle)
-                obj.vehicle.setCoordinateSystem(1,2,0)
+                obj.vehicle.setCoordinateSystem(1, 2, 0)
 
                 for w in obj.wheels:
-                    wheel=obj.vehicle.addWheel(Vector3f(w.x,w.y,w.z),Vector3f(w.dir),Vector3f(w.axle),w.suspension_rest_len,w.radius,tuning,False)
-                    wheel.suspensionStiffness=w.suspension_stiffness
-                    wheel.maxSuspensionTravelCm=w.suspension_max_travel*100
-                    wheel.frictionSlip=w.friction
-                    wheel.wheelsDampingRelaxation=w.damping_relaxation
-                    wheel.wheelsDampingCompression=w.damping_compression
-                    wheel.rollInfluence=w.roll_influence
+                    wheel = obj.vehicle.addWheel(Vector3f(w.x, w.y, w.z),
+                                                 Vector3f(w.dir),
+                                                 Vector3f(w.axle),
+                                                 w.suspension_rest_len,
+                                                 w.radius,
+                                                 tuning,
+                                                 False)
+                    wheel.suspensionStiffness = w.suspension_stiffness
+                    wheel.maxSuspensionTravelCm = w.suspension_max_travel * 100
+                    wheel.frictionSlip = w.friction
+                    wheel.wheelsDampingRelaxation = w.damping_relaxation
+                    wheel.wheelsDampingCompression = w.damping_compression
+                    wheel.rollInfluence = w.roll_influence
 
         self.objects.append(obj)
         self.world.addObject(obj.shape)
 
-
-
     def start(self):
-        dt=self.dt
+        dt = self.dt
         while True:
-            p=self.physics_dump()
-            #self.update_shapes(p)
+            self.physics_dump()
+            # p = self.physics_dump()
+            # self.update_shapes(p)
             for obj in self.objects:
-                if hasattr(obj,'vehicle'):
-                    for i,w in enumerate(obj.wheels):
-                        obj.vehicle.updateWheelTransform(i, True);
-                        obj.vehicle.applyEngineForce(w.force,i)
-                        #obj.vehicle.setBrake(w.brake,i)
+                if hasattr(obj, 'vehicle'):
+                    for i, w in enumerate(obj.wheels):
+                        obj.vehicle.updateWheelTransform(i, True)
+                        obj.vehicle.applyEngineForce(w.force, i)
+                        # obj.vehicle.setBrake(w.brake, i)
 
-            self.physics.stepSimulation(dt,10,dt*0.1)
+            self.physics.stepSimulation(dt, 10, dt * 0.1)
             yield dt
+
     def physics_dump(self):
-        d={}
+        d = {}
         for obj in self.objects:
-            if hasattr(obj,'physics'):
-                t=Transform()
+            if hasattr(obj, 'physics'):
+                t = Transform()
                 obj.physics.getMotionState().getWorldTransform(t)
-                m=Matrix4f()
+                m = Matrix4f()
                 t.getMatrix(m)
 
-                trans=Matrix()
-                trans.set(3,0,m.m03)
-                trans.set(3,1,m.m13)
-                trans.set(3,2,m.m23)
-                rot=Matrix()
+                trans = Matrix()
+                trans.set(3, 0, m.m03)
+                trans.set(3, 1, m.m13)
+                trans.set(3, 2, m.m23)
+                rot = Matrix()
                 for i in range(3):
                     for j in range(3):
-                        rot.set(i,j,m.getElement(j,i))
-                d[obj]=(trans,rot)
+                        rot.set(i, j, m.getElement(j, i))
+                d[obj] = (trans, rot)
         return d
 
-    def update_shapes(self,physics):
+    def update_shapes(self, physics):
         for obj in self.objects:
-            if hasattr(obj,'physics') and obj in physics:
-                trans,rot=physics[obj]
-                obj.shape.translationMatrix=trans
-                obj.shape.rotationMatrix=rot
-                if hasattr(obj,'extra_shapes'):
-                    for s,x,y,z in obj.extra_shapes:
-                        p=SimpleVector(x,y,z)
+            if hasattr(obj, 'physics') and obj in physics:
+                trans, rot = physics[obj]
+                obj.shape.translationMatrix = trans
+                obj.shape.rotationMatrix = rot
+                if hasattr(obj, 'extra_shapes'):
+                    for s, x, y, z in obj.extra_shapes:
+                        p = SimpleVector(x, y, z)
                         p.matMul(rot)
-                        m4=Matrix(trans)
+                        m4 = Matrix(trans)
                         m4.translate(p)
-                        s.translationMatrix=m4
-                        s.rotationMatrix=rot
+                        s.translationMatrix = m4
+                        s.rotationMatrix = rot
 
 
 class Wheel:
-    def __init__(self,x,y,z,dir=(0,0,-1),axle=(0,-1,0),radius=0.3,
-                        suspension_stiffness=20,suspension_max_travel=0.1,suspension_rest_len=0,
-                        friction=10,damping_relaxation=2.3,damping_compression=4.4,roll_influence=0.1):
-        self.x=x
-        self.y=y
-        self.z=z
-        self.dir=dir
-        self.axle=axle
-        self.radius=radius
-        self.suspension_stiffness=suspension_stiffness
-        self.suspension_max_travel=suspension_max_travel
-        self.suspension_rest_len=suspension_rest_len
-        self.friction=friction
-        self.damping_relaxation=damping_relaxation
-        self.damping_compression=damping_compression
-        self.roll_influence=roll_influence
+    def __init__(self, x, y, z, dir=(0, 0, -1), axle=(0, -1, 0), radius=0.3,
+                 suspension_stiffness=20, suspension_max_travel=0.1,
+                 suspension_rest_len=0, friction=10, damping_relaxation=2.3,
+                 damping_compression=4.4, roll_influence=0.1):
+        self.x = x
+        self.y = y
+        self.z = z
+        self.dir = dir
+        self.axle = axle
+        self.radius = radius
+        self.suspension_stiffness = suspension_stiffness
+        self.suspension_max_travel = suspension_max_travel
+        self.suspension_rest_len = suspension_rest_len
+        self.friction = friction
+        self.damping_relaxation = damping_relaxation
+        self.damping_compression = damping_compression
+        self.roll_influence = roll_influence
 
-        self.force=0
-        self.brake=0
+        self.force = 0
+        self.brake = 0
 
 
 class RangeSensorCallback(CollisionWorld.RayResultCallback):
-    def __init__(self,sensor):
+    def __init__(self, sensor):
         CollisionWorld.RayResultCallback.__init__(self)
-        self.sensor=sensor
-    def addSingleResult(self,result,normal):
+        self.sensor = sensor
+
+    def addSingleResult(self, result, normal):
         print result
 
+
 class RangeSensor(ccm.Model):
-    def __init__(self,x,y,z,origin=(0,0,0),maximum=100,timestep=0.01):
+    def __init__(self, x, y, z, origin=(0, 0, 0), maximum=100, timestep=0.01):
         ccm.Model.__init__(self)
-        self.dir=Vector3f(x,y,z)
+        self.dir = Vector3f(x, y, z)
         self.dir.normalize()
         self.dir.scale(maximum)
 
-        self.origin=Vector3f(origin)
+        self.origin = Vector3f(origin)
 
-        self.range=0
-        self.timestep=timestep
+        self.range = 0
+        self.timestep = timestep
 
     def start(self):
         while True:
-            physics=self.parent.parent.physics
+            physics = self.parent.parent.physics
 
-            t=Transform()
+            t = Transform()
             self.parent.physics.getWorldTransform(t)
-            pt1=Vector3f(self.origin)
-            pt2=Vector3f(self.dir)
+            pt1 = Vector3f(self.origin)
+            pt2 = Vector3f(self.dir)
             t.transform(pt1)
             t.transform(pt2)
 
-            callback=CollisionWorld.ClosestRayResultCallback(pt1,pt2)
-            physics.rayTest(pt1,pt2,callback)
+            callback = CollisionWorld.ClosestRayResultCallback(pt1, pt2)
+            physics.rayTest(pt1, pt2, callback)
 
-            delta=Vector3f(callback.hitPointWorld)
+            delta = Vector3f(callback.hitPointWorld)
             delta.sub(pt1)
-            self.range=delta.length()
+            self.range = delta.length()
 
             yield self.timestep
 
 
-
-
-
-
-
-
 class Box(ccm.Model):
-    def __init__(self, x, y, z, mass=1,scale=1, draw_as_cylinder=False,color=Color.blue,overdraw_length=1,overdraw_radius=1,flat_shading=False):
+    def __init__(self, x, y, z, mass=1, scale=1, draw_as_cylinder=False,
+                 color=Color.blue, overdraw_length=1, overdraw_radius=1,
+                 flat_shading=False):
 
         if draw_as_cylinder:
-            if y is max(x,y,z):
-                radius=(x+z)/4*overdraw_radius
-                self.shape=Primitives.getCylinder(90,radius,y/(radius*2)*overdraw_length)
-            if z is max(x,y,z):
-                radius=(x+y)/4*overdraw_radius
-                self.shape=Primitives.getCylinder(90,radius,z/(radius*2)*overdraw_length)
-                self.shape.rotateX(math.pi/2)
+            if y is max(x, y, z):
+                radius = (x + z) / 4 * overdraw_radius
+                self.shape = Primitives.getCylinder(
+                    90, radius, y / (radius * 2) * overdraw_length)
+            if z is max(x, y, z):
+                radius = (x + y) / 4 * overdraw_radius
+                self.shape = Primitives.getCylinder(
+                    90, radius, z / (radius * 2) * overdraw_length)
+                self.shape.rotateX(math.pi / 2)
                 self.shape.rotateMesh()
         else:
-            self.shape=createBox(x/2.0*scale, y/2.0*scale, z/2.0*scale)
-        if flat_shading: self.shape.shadingMode=Object3D.SHADING_FAKED_FLAT
+            self.shape = createBox(x / 2.0 * scale,
+                                   y / 2.0 * scale,
+                                   z / 2.0 * scale)
+        if flat_shading:
+            self.shape.shadingMode = Object3D.SHADING_FAKED_FLAT
 
-        colorname='box%d'%id(self)
-        TextureManager.getInstance().addTexture(colorname,Texture(1, 1, color))
+        colorname = 'box%d' % id(self)
+        TextureManager.getInstance().addTexture(colorname, Texture(1, 1, color))
         self.shape.setTexture(colorname)
         self.shape.build()
 
-        shape=BoxShape(Vector3f(x/2.0,y/2.0,z/2.0))
+        shape = BoxShape(Vector3f(x / 2.0, y / 2.0, z / 2.0))
 
-        inertia=Vector3f(0,0,0)
-        shape.calculateLocalInertia(mass,inertia)
+        inertia = Vector3f(0, 0, 0)
+        shape.calculateLocalInertia(mass, inertia)
 
-        t=Transform()
+        t = Transform()
         t.setIdentity()
 
-        ms=DefaultMotionState(t)
-        rb=RigidBodyConstructionInfo(mass,ms,shape,inertia)
-        self.physics=RigidBody(rb)
+        ms = DefaultMotionState(t)
+        rb = RigidBodyConstructionInfo(mass, ms, shape, inertia)
+        self.physics = RigidBody(rb)
 
-    def add_sphere_at(self,x,y,z,radius,color,room):
-        s=Primitives.getSphere(radius)
+    def add_sphere_at(self, x, y, z, radius, color, room):
+        s = Primitives.getSphere(radius)
 
-        colorname='added_sphere_%d'%id(s)
-        TextureManager.getInstance().addTexture(colorname,Texture(1,1,color))
+        colorname = 'added_sphere_%d' % id(s)
+        TextureManager.getInstance().addTexture(
+            colorname, Texture(1, 1, color))
         s.setTexture(colorname)
         s.build()
-        if not hasattr(self,'extra_shapes'):
-            self.extra_shapes=[]
-        self.extra_shapes.append((s,x,y,z))
+        if not hasattr(self, 'extra_shapes'):
+            self.extra_shapes = []
+        self.extra_shapes.append((s, x, y, z))
         room.world.addObject(s)
 
 
 class Sphere(ccm.Model):
-    def __init__(self, r, mass=1,color=Color.red):
-        colorname='sphere_%d'%id(self)
-        self.shape=Primitives.getSphere(r)
-        TextureManager.getInstance().addTexture(colorname,Texture(1, 1, color))
+    def __init__(self, r, mass=1, color=Color.red):
+        colorname = 'sphere_%d' % id(self)
+        self.shape = Primitives.getSphere(r)
+        TextureManager.getInstance().addTexture(
+            colorname, Texture(1, 1, color))
         self.shape.setTexture(colorname)
         self.shape.build()
 
-        shape=BoxShape(Vector3f(r/2.0,r/2.0,r/2.0))
+        shape = BoxShape(Vector3f(r / 2.0, r / 2.0, r / 2.0))
 
-        inertia=Vector3f(0,0,0)
-        shape.calculateLocalInertia(mass,inertia)
+        inertia = Vector3f(0, 0, 0)
+        shape.calculateLocalInertia(mass, inertia)
 
-        t=Transform()
+        t = Transform()
         t.setIdentity()
 
-        ms=DefaultMotionState(t)
-        rb=RigidBodyConstructionInfo(mass,ms,shape,inertia)
-        self.physics=RigidBody(rb)
+        ms = DefaultMotionState(t)
+        rb = RigidBodyConstructionInfo(mass, ms, shape, inertia)
+        self.physics = RigidBody(rb)
 
 
-import math
 class MD2(ccm.Model):
-    _shapes={}
-    def __init__(self, filename, texture, scale=1.0, mass=1,overdraw_scale=1.0):
+    _shapes = {}
+
+    def __init__(self, filename, texture,
+                 scale=1.0, mass=1, overdraw_scale=1.0):
         if not TextureManager.getInstance().containsTexture(texture):
-            TextureManager.getInstance().addTexture(texture,Texture(texture))
-        if (filename,scale) not in MD2._shapes:
-            shape=Loader.loadMD2(filename, scale)
+            TextureManager.getInstance().addTexture(texture, Texture(texture))
+        if (filename, scale) not in MD2._shapes:
+            shape = Loader.loadMD2(filename, scale)
             shape.rotateAxis(SimpleVector(1, 0, 0), math.pi/2)
             shape.rotateAxis(SimpleVector(0, 0, 1), -math.pi/2)
             shape.rotateMesh()
-            shape.rotationMatrix=Matrix()
+            shape.rotationMatrix = Matrix()
 
-            MD2._shapes[(filename,scale)]=shape
-        #self.shape=MD2._shapes[(filename,scale)].cloneObject()
-        self.shape=Object3D(MD2._shapes[(filename,scale)],False)
+            MD2._shapes[(filename, scale)] = shape
+        # self.shape = MD2._shapes[(filename, scale)].cloneObject()
+        self.shape = Object3D(MD2._shapes[(filename, scale)], False)
         self.shape.build()
         self.shape.setTexture(texture)
-        minx,maxx,miny,maxy,minz,maxz=self.shape.mesh.boundingBox
-        shape=BoxShape(Vector3f((maxx-minx)/overdraw_scale/2.0,(maxy-miny)/overdraw_scale/2.0,(maxz-minz)/2.0))
-        t=Transform()
+        minx, maxx, miny, maxy, minz, maxz = self.shape.mesh.boundingBox
+        shape = BoxShape(Vector3f((maxx - minx) / overdraw_scale / 2.0,
+                                  (maxy - miny) / overdraw_scale / 2.0,
+                                  (maxz - minz) / 2.0))
+        t = Transform()
         t.setIdentity()
-        t.origin.x=(maxx+minx)/2
-        t.origin.y=(maxy+miny)/2
-        t.origin.z=(maxz+minz)/2
-        ms=DefaultMotionState(t)
-        inertia=Vector3f(0,0,0)
-        shape.calculateLocalInertia(mass,inertia)
-        rb=RigidBodyConstructionInfo(mass,ms,shape,inertia)
-        self.physics=RigidBody(rb)
-        self.shape.setOrigin(SimpleVector(-(maxx+minx)/2,-(maxy+miny)/2,-(maxz+minz)/2))
-
+        t.origin.x = (maxx + minx) / 2
+        t.origin.y = (maxy + miny) / 2
+        t.origin.z = (maxz + minz) / 2
+        ms = DefaultMotionState(t)
+        inertia = Vector3f(0, 0, 0)
+        shape.calculateLocalInertia(mass, inertia)
+        rb = RigidBodyConstructionInfo(mass, ms, shape, inertia)
+        self.physics = RigidBody(rb)
+        self.shape.setOrigin(SimpleVector(-(maxx + minx) / 2,
+                                          -(maxy + miny) / 2,
+                                          -(maxz + minz) / 2))
 
     def start(self):
-        self.frame=0
+        self.frame = 0
         self.sch.add(self.animate)
 
     def animate(self):
-        self.frame=(self.frame+0.002)
-        while self.frame>1: self.frame-=1
+        self.frame = self.frame + 0.002
+        while self.frame > 1:
+            self.frame -= 1
         self.shape.animate(self.frame, 1)
         return 0.01
 
 
 class RateLimit(ccm.Model):
     def start(self):
-        if not hasattr(self.sch,'rate'): self.sch.rate=1
-        dt=0.001
+        if not hasattr(self.sch, 'rate'):
+            self.sch.rate = 1
+        dt = 0.01
         while True:
-            real1=java.lang.System.nanoTime()*0.000000001
+            real1 = java.lang.System.currentTimeMillis() * 0.001
             yield dt
-            real2=java.lang.System.nanoTime()*0.000000001
-            while (real2-real1)*self.sch.rate<dt:
-                real2=java.lang.System.nanoTime()*0.000000001
-
-class RateLimit(ccm.Model):
-    def start(self):
-        if not hasattr(self.sch,'rate'): self.sch.rate=1
-        dt=0.01
-        while True:
-            real1=java.lang.System.currentTimeMillis()*0.001
-            yield dt
-            real2=java.lang.System.currentTimeMillis()*0.001
-            while (real2-real1)*self.sch.rate<dt:
-                real2=java.lang.System.currentTimeMillis()*0.001
+            real2 = java.lang.System.currentTimeMillis() * 0.001
+            while (real2-real1) * self.sch.rate < dt:
+                real2 = java.lang.System.currentTimeMillis() * 0.001
                 java.lang.Thread.currentThread().sleep(1)
 
 
-
-
-
-
 class View(JComponent):
-    def __init__(self, obj, location, size=(800, 600),keys=None):
+    def __init__(self, obj, location, size=(800, 600), keys=None):
         JComponent.__init__(self)
-        self.location=list(location)
-        self.buffer=FrameBuffer(size[0], size[1], FrameBuffer.SAMPLINGMODE_NORMAL)
-        self.obj=obj
-        self.frame=JFrame(keyPressed=self.keyPressed,keyReleased=self.keyReleased)
+        self.location = list(location)
+        self.buffer = FrameBuffer(
+            size[0], size[1], FrameBuffer.SAMPLINGMODE_NORMAL)
+        self.obj = obj
+        self.frame = JFrame(keyPressed=self.keyPressed,
+                            keyReleased=self.keyReleased)
         self.frame.add(self)
-        self.size=size
+        self.size = size
         self.frame.pack()
-        self.frame.size=size
-        self.frame.visible=True
-        self.clearColor=Color(0x666666)
-        self.keys=keys
+        self.frame.size = size
+        self.frame.visible = True
+        self.clearColor = Color(0x666666)
+        self.keys = keys
 
     def paint(self, g):
-        x, y, z=self.location
+        x, y, z = self.location
         self.obj.world.camera.setPosition(x, -y, z)
         self.obj.world.camera.lookAt(SimpleVector(0, 0, 0))
 
@@ -473,31 +555,30 @@ class View(JComponent):
         self.buffer.display(g)
         self.repaint()
 
-    def keyReleased(self,event):
-        if self.keys is not None and hasattr(self.keys,'key_released'):
+    def keyReleased(self, event):
+        if self.keys is not None and hasattr(self.keys, 'key_released'):
             self.keys.key_released(KeyEvent.getKeyText(event.keyCode))
 
-
-    def keyPressed(self,event):
-        if self.keys is not None and hasattr(self.keys,'key_pressed'):
+    def keyPressed(self, event):
+        if self.keys is not None and hasattr(self.keys, 'key_pressed'):
             self.keys.key_pressed(KeyEvent.getKeyText(event.keyCode))
-        if event.keyCode==KeyEvent.VK_ESCAPE:
+        if event.keyCode == KeyEvent.VK_ESCAPE:
             self.frame.dispose()
-        elif event.keyCode==KeyEvent.VK_PAGE_UP:
-            self.obj.sch.rate*=1.1
-            self.frame.title='rate: %1.3f'%self.obj.sch.rate
-        elif event.keyCode==KeyEvent.VK_PAGE_DOWN:
-            self.obj.sch.rate/=1.1
-            self.frame.title='rate: %1.3f'%self.obj.sch.rate
-        elif event.keyCode==KeyEvent.VK_Z:
-            self.location[2]+=1
-        elif event.keyCode==KeyEvent.VK_X:
-            self.location[2]-=1
-        elif event.keyCode==KeyEvent.VK_W:
-            self.location[1]+=1
-        elif event.keyCode==KeyEvent.VK_S:
-            self.location[1]-=1
-        elif event.keyCode==KeyEvent.VK_A:
-            self.location[0]+=1
-        elif event.keyCode==KeyEvent.VK_D:
-            self.location[0]-=1
+        elif event.keyCode == KeyEvent.VK_PAGE_UP:
+            self.obj.sch.rate *= 1.1
+            self.frame.title = 'rate: %1.3f' % self.obj.sch.rate
+        elif event.keyCode == KeyEvent.VK_PAGE_DOWN:
+            self.obj.sch.rate /= 1.1
+            self.frame.title = 'rate: %1.3f' % self.obj.sch.rate
+        elif event.keyCode == KeyEvent.VK_Z:
+            self.location[2] += 1
+        elif event.keyCode == KeyEvent.VK_X:
+            self.location[2] -= 1
+        elif event.keyCode == KeyEvent.VK_W:
+            self.location[1] += 1
+        elif event.keyCode == KeyEvent.VK_S:
+            self.location[1] -= 1
+        elif event.keyCode == KeyEvent.VK_A:
+            self.location[0] += 1
+        elif event.keyCode == KeyEvent.VK_D:
+            self.location[0] -= 1

--- a/simulator-ui/python/stats/view/jython/core.py
+++ b/simulator-ui/python/stats/view/jython/core.py
@@ -1,6 +1,6 @@
-from javax.swing import *
-from java.awt import *
-from java.awt.event import *
+from javax.swing import JFrame
+from java.awt import BorderLayout
+from java.awt.event import ItemEvent
 
 import stats
 
@@ -8,26 +8,26 @@ from .graph import GraphPanel
 from .run import RunPanel
 from .options import OptionsPanel
 from .model import ModelSelectionPanel
-        
 
-                
+
+
 class View:
     def __init__(self):
         self.stats=None
         self.frame=JFrame('Statistics',visible=True,layout=BorderLayout())
-        
+
         self.graph=GraphPanel(self,componentResized=lambda event: self.graph.update())
         self.frame.add(self.graph)
-        
+
         self.options=OptionsPanel(self)
         self.frame.add(self.options,BorderLayout.WEST)
-        
-        
+
+
         self.model_selection=ModelSelectionPanel(self)
         self.frame.add(self.model_selection,BorderLayout.NORTH)
-        
+
         self.frame.add(RunPanel(self),BorderLayout.SOUTH)
-        
+
         self.frame.size=(800,600)
     def selected_params(self):
         return self.options.parameters.get_selected()
@@ -37,16 +37,9 @@ class View:
             self.select_model(event.item)
 
 
-    
+
     def select_model(self,name):
-        self.model_selection.files.selectedItem=name        
+        self.model_selection.files.selectedItem=name
         self.stats=stats.Stats(name)
         self.options.update()
         self.graph.update()
-            
-            
-
-
-        
-        
-        

--- a/simulator-ui/python/stats/view/jython/graph.py
+++ b/simulator-ui/python/stats/view/jython/graph.py
@@ -1,6 +1,6 @@
 import java
-from javax.swing import *
-from java.awt import *
+from javax.swing import ImageIcon, JLabel, JPanel
+from java.awt import BorderLayout
 
 import os
 import time
@@ -21,8 +21,8 @@ class GraphPanel(JPanel,java.lang.Runnable):
     def update(self):
         self.should_update=True
         self.graph.enabled=False
-        
-    
+
+
     def run(self):
         while True:
             if self.should_update:
@@ -30,36 +30,37 @@ class GraphPanel(JPanel,java.lang.Runnable):
                 self.do_update()
             if self.should_update:
                 self.graph.enabled=False
-            else:    
-                time.sleep(0.1)    
-    def do_update(self):            
+            else:
+                time.sleep(0.1)
+    def do_update(self):
         if self.view.stats is None: return
         if len(self.view.stats.data)==0: return
         #print 'update graph'
-        
+
         for f in os.listdir('python'):
             if f.startswith('.view.') and f.endswith('.png'):
                 os.remove('python/'+f)
-        
+
         fn='python/.view.%08x'%random.randrange(0x7fffffff)
-        
+
         code=self.make_pylab_code(fn+'.png')
         #print code
         f=open(fn+'.py','w')
         f.write(code)
         f.close()
         os.system('python %s.py'%fn)
-        
+
         icon=ImageIcon(fn+'.png')
         self.graph.icon=icon
         self.graph.enabled=True
         os.remove(fn+'.py')
         self.revalidate()
-    
+
     def make_pylab_code(self,filename):
         opt=self.view.options
+        g_opt = getattr(opt, 'global')
 
-        dpi=opt.global.dpi.text
+        dpi=g_opt.dpi.text
         try: dpi=int(dpi)
         except: dpi=80
 
@@ -71,30 +72,29 @@ class GraphPanel(JPanel,java.lang.Runnable):
         for k,v in params.items():
             if isinstance(v,list) and len(v)==1: params[k]=v[0]
         lines.append('s=s(%s)'%','.join(['%s=%s'%(k,`v`) for k,v in params.items()]))
-        
+
         lines.append('import stats.plot')
-        color=opt.global.opt_color.isSelected()
+        color=g_opt.opt_color.isSelected()
         values=self.view.stats.data[0].computed.value_names()
-        metric=opt.global.metrics.selectedItem
-        
+        metric=g_opt.metrics.selectedItem
+
         width=self.size.width/float(dpi)
         height=self.size.height/float(dpi)
         if opt.get_graph_type()=='bar':
             lines.append('p=stats.plot.Bar(width=%g,height=%g,color=%s)'%(
-                                    width,height,color))        
+                                    width,height,color))
             scatter=opt.bar_tab.show_samples.isSelected()
             lines.append('p.plot(s,values=%s,scatter=%s,metric=%s)'%(`values`,`scatter`,`metric`))
         elif opt.get_graph_type()=='line':
-            
-            spaced=opt.line_tab.x_axis.selectedItem=='equal'        
-            logx=opt.line_tab.x_axis.selectedItem=='log'        
-            logy=opt.line_tab.y_axis.selectedItem=='log'        
+
+            spaced=opt.line_tab.x_axis.selectedItem=='equal'
+            logx=opt.line_tab.x_axis.selectedItem=='log'
+            logy=opt.line_tab.y_axis.selectedItem=='log'
             lines.append('p=stats.plot.Line(width=%g,height=%g,color=%s,log_x=%s,log_y=%s,spaced=%s)'%(
-                                    width,height,color,logx,logy,spaced)) 
+                                    width,height,color,logx,logy,spaced))
             area=opt.line_tab.area.isSelected()
             lines.append('p.plot(s,values=%s,area=%s,metric=%s)'%(`values`,`area`,`metric`))
-        
-        lines.append('p.save("%s",dpi=%d)'%(filename,dpi)) 
-        
-        return '\n'.join(lines)
 
+        lines.append('p.save("%s",dpi=%d)'%(filename,dpi))
+
+        return '\n'.join(lines)

--- a/simulator-ui/python/stats/view/jython/model.py
+++ b/simulator-ui/python/stats/view/jython/model.py
@@ -1,5 +1,6 @@
-from javax.swing import *
-from java.awt import *
+from javax.swing import (
+    DefaultComboBoxModel, ImageIcon, JButton, JComboBox, JLabel, JPanel)
+from java.awt import BorderLayout
 
 import os
 
@@ -13,12 +14,12 @@ class ModelSelectionPanel(JPanel):
 
         self.layout=BorderLayout()
         self.add(self.files)
-        
+
         self.add(JLabel('select model:'),BorderLayout.WEST)
-        
+
         #TODO: make this button open a file dialog, allowing directory changes
-        self.add(JButton(icon=ImageIcon('python/images/open.png')),BorderLayout.EAST)            
-        
+        self.add(JButton(icon=ImageIcon('python/images/open.png')),BorderLayout.EAST)
+
     def find_files(self):
         selected=self.files.selectedItem
         files=set()
@@ -27,5 +28,3 @@ class ModelSelectionPanel(JPanel):
             elif os.path.exists(os.path.join(self.dir,f,'code.py')): files.add(f)
         self.files.model=DefaultComboBoxModel(sorted(files))
         self.files.selectedItem=selected
-        
-

--- a/simulator-ui/python/stats/view/jython/options.py
+++ b/simulator-ui/python/stats/view/jython/options.py
@@ -1,7 +1,8 @@
-import java
-from javax.swing import *
-from java.awt import *
-from java.awt.event import *
+from javax.swing import (
+    BorderFactory, BoxLayout, DefaultListModel, JCheckBox, JComboBox, JLabel,
+    JList, JPanel, JTabbedPane, JTextField, SwingConstants)
+from java.awt import BorderLayout, Color
+from java.awt.event import ActionListener
 
 class ParameterPanel(JPanel):
     def __init__(self,view,name,values,default):
@@ -14,11 +15,11 @@ class ParameterPanel(JPanel):
         self.add(JLabel(name,horizontalAlignment=SwingConstants.LEFT),BorderLayout.NORTH)
         self.new_value=JTextField('',actionPerformed=self.create_new_value)
         self.add(self.new_value,BorderLayout.SOUTH)
-        self.add(self.values)      
+        self.add(self.values)
         self.values.setSelectedValue(default,True)
     def adjust(self,event):
         if not event.valueIsAdjusting:
-            self.view.graph.update()    
+            self.view.graph.update()
     def create_new_value(self,event):
         value=self.new_value.text
         self.new_value.text=''
@@ -32,10 +33,10 @@ class ParameterPanel(JPanel):
             self.values_data.sort()
             model=DefaultListModel()
             for v in self.values_data:
-                model.addElement(v) 
-            self.values.model=model    
-            self.values.setSelectedValue(selected,True) 
-        
+                model.addElement(v)
+            self.values.model=model
+            self.values.setSelectedValue(selected,True)
+
 class ParametersPanel(JPanel):
     def __init__(self,view):
         self.view=view
@@ -51,15 +52,15 @@ class ParametersPanel(JPanel):
         values={}
         for k,v in self.params.items():
             values[k]=[x for x in v.values.selectedValues]
-        return values    
+        return values
 
 class BarTab(JPanel):
     def __init__(self,options):
         self.options=options
-                        
+
         self.show_samples=JCheckBox('Show samples',False,actionPerformed=self.options.changed)
         self.add(self.show_samples)
-        
+
 class LineTab(JPanel,ActionListener):
     def __init__(self,options):
         self.options=options
@@ -82,15 +83,15 @@ class LineTab(JPanel,ActionListener):
         axis.maximumSize=axis.minimumSize
         self.add(axis)
     def actionPerformed(self,event):
-        self.options.changed(event)    
-        
-        
+        self.options.changed(event)
+
+
 def make_option(label,component):
     panel=JPanel(layout=BorderLayout())
     panel.add(JLabel(label+':'),BorderLayout.WEST)
     panel.add(component)
-    return panel        
-        
+    return panel
+
 class GlobalPanel(JPanel, ActionListener):
     def __init__(self,options):
         self.options=options
@@ -100,43 +101,41 @@ class GlobalPanel(JPanel, ActionListener):
         self.add(self.opt_color)
         self.dpi=JTextField('80',actionPerformed=self.options.changed)
         self.add(make_option('dpi',self.dpi))
-        
+
         self.metrics=JComboBox(['mean','median','sd','var'],editable=False)
         self.metrics.selectedIndex=0
         self.metrics.addActionListener(self)
         self.add(make_option('metric',self.metrics))
     def actionPerformed(self,event):
-        self.options.changed(event)    
-        
-                
-        
+        self.options.changed(event)
+
+
+
 class OptionsPanel(JPanel):
     def __init__(self,view):
         self.view=view
         self.layout=BorderLayout()
         self.parameters=ParametersPanel(self.view)
         self.add(self.parameters,BorderLayout.NORTH)
-        
+
         self.tabs=JTabbedPane(stateChanged=self.changed)
         self.bar_tab=BarTab(self)
         self.line_tab=LineTab(self)
         self.tabs.addTab('Bar',self.bar_tab)
         self.tabs.addTab('Line',self.line_tab)
         self.add(self.tabs)
-        
-        self.global=GlobalPanel(self)
-        self.add(self.global,BorderLayout.SOUTH)
+
+        setattr(self, 'global', GlobalPanel(self))
+        self.add(getattr(self, 'global'), BorderLayout.SOUTH)
     def get_graph_type(self):
         if self.tabs.selectedIndex==0:
             return 'bar'
         elif self.tabs.selectedIndex==1:
             return 'line'
         else:
-            return None    
-        
+            return None
+
     def update(self):
         self.parameters.update(self.view.stats.params,self.view.stats.options,self.view.stats.defaults)
     def changed(self,event):
-        self.view.graph.update()    
-            
-
+        self.view.graph.update()

--- a/simulator-ui/python/stats/view/jython/run.py
+++ b/simulator-ui/python/stats/view/jython/run.py
@@ -1,6 +1,6 @@
 import java
-from javax.swing import *
-from java.awt import *
+from javax.swing import JCheckBox, JPanel
+from java.awt import BorderLayout
 
 import time
 
@@ -21,6 +21,5 @@ class RunPanel(JPanel, java.lang.Runnable):
                 params=self.view.selected_params()
                 print params
                 self.view.stats(**params).run(call_after=self.view.graph.update)
-            else:    
+            else:
                 time.sleep(0.1)
-

--- a/simulator-ui/python/timeview/components/boxes.py
+++ b/simulator-ui/python/timeview/components/boxes.py
@@ -1,11 +1,6 @@
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
+from java.awt import Color
 
 import core
-
-from math import sqrt
 
 
 class Boxes(core.DataViewComponent):
@@ -19,21 +14,21 @@ class Boxes(core.DataViewComponent):
         self.margin = 0
         self.setSize(200, 200)
         self.boxes = None
-        
+
     def tick(self, t):
         try:
             self.boxes = self.data.get(start=self.view.current_tick, count=1)[0]
         except Exception,e:
             print "error in get",e
             return
-        
+
         self.minx = 1000
         self.maxx = -1000
         self.miny = 1000
         self.maxy = -1000
-        
+
         self.convert_coords()
-        
+
         for b in self.boxes:
             x0,y0 = b[1]
             x1,y1 = b[2]
@@ -46,11 +41,11 @@ class Boxes(core.DataViewComponent):
                 self.miny = y0
             if y1 > self.maxy:
                 self.maxy = y1
-                
+
         self.xscale = self.size.width / (self.maxx - self.minx)
         self.yscale = self.size.height / (self.maxy - self.miny)
-        
-#        print (self.maxx-self.minx)*self.xscale,(self.maxy-self.miny)*self.yscale 
+
+#        print (self.maxx-self.minx)*self.xscale,(self.maxy-self.miny)*self.yscale
 #        print self.minx,self.maxx,self.xscale
 #        print self.miny,self.maxy,self.yscale
 
@@ -58,19 +53,19 @@ class Boxes(core.DataViewComponent):
         #convert euclidian points to drawing points
         minx = min([b[i][0] for b in self.boxes for i in range(1,2)])
         miny = min([-b[i][1] for b in self.boxes for i in range(1,2)])
-        
+
         def conv(pt):
             x,y = pt
             return (x-minx,-y-miny)
-        
+
         self.boxes = [[b[0],conv(b[1]),conv(b[2])] for b in self.boxes]
-                       
+
     def paintComponent(self, g):
         core.DataViewComponent.paintComponent(self, g)
 
         if self.boxes is None:
             return
-        
+
         for b in self.boxes:
             if b[0] == "-":
                 g.color = Color.black

--- a/simulator-ui/python/timeview/components/colorgrid.py
+++ b/simulator-ui/python/timeview/components/colorgrid.py
@@ -1,7 +1,4 @@
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
+from java.awt import Color
 
 import core
 
@@ -19,13 +16,13 @@ class ColorGrid(core.DataViewComponent):
         self.rows = rows
         self.margin = 10
         self.setSize(200, 200)
-        
+
     def tick(self, t):
         try:
-            self.grid = self.data.get(start=self.view.current_tick, count=1, dt_tau=dt_tau)[0]
+            self.grid = self.data.get(start=self.view.current_tick, count=1)[0]
         except:
             return
-        
+
         if self.rows is None:
             self.rows = int(sqrt(len(self.grid)))
 
@@ -33,7 +30,7 @@ class ColorGrid(core.DataViewComponent):
         if self.rows * self.cols < len(self.grid):
             self.cols += 1
 
-        
+
 
     def paintComponent(self, g):
         core.DataViewComponent.paintComponent(self, g)
@@ -46,7 +43,7 @@ class ColorGrid(core.DataViewComponent):
 
         if self.grid is None:
             return
-        
+
         dx = float(self.size.width - self.margin) / self.cols
         dy = float(self.size.height - self.label_offset - self.margin) / self.rows
 
@@ -60,5 +57,5 @@ class ColorGrid(core.DataViewComponent):
                     elif isinstance(dat, (list,tuple)):
                         g.color = Color(dat[0], dat[1], dat[2])
                     elif isinstance(dat, float):
-                        g.color = Color(dat, dat, dat) 
+                        g.color = Color(dat, dat, dat)
                     g.fillRect(int(x0 + dx * x), int(y0 + dy * y), int(dx + 1), int(dy + 1))

--- a/simulator-ui/python/timeview/components/core.py
+++ b/simulator-ui/python/timeview/components/core.py
@@ -1,7 +1,8 @@
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
+from javax.swing import (
+    BorderFactory, JCheckBoxMenuItem, JMenuItem, JPanel, JPopupMenu)
+from java.awt import Color, Cursor, RenderingHints
+from java.awt.event import (ActionListener, MouseEvent, MouseMotionListener,
+                            MouseListener, MouseWheelListener)
 import javax
 import java
 
@@ -213,7 +214,7 @@ class DataViewComponent(JPanel, MouseListener, MouseWheelListener, MouseMotionLi
             g.color = Color(0.3, 0.3, 0.3)
             bounds = g.font.getStringBounds(self.label, g.fontRenderContext)
             g.drawString(self.label, self.size.width / 2 - bounds.width / 2, bounds.height)
-            
+
     def tick(self, t):
         """This method will be called in the simulation timescale (as opposed to the rendering
         timescale of paintComponent).  This is useful for updating the data that will
@@ -222,6 +223,6 @@ class DataViewComponent(JPanel, MouseListener, MouseWheelListener, MouseMotionLi
         simulation timestep; for example, if the simulation is running very quickly,
         it would not be desirable to be updating the data far more quickly than it can be
         displayed.
-        
+
         :param float t: the current simulation time"""
         pass

--- a/simulator-ui/python/timeview/components/drawimage.py
+++ b/simulator-ui/python/timeview/components/drawimage.py
@@ -1,8 +1,3 @@
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
-
 import core
 
 class DrawImage(core.DataViewComponent):
@@ -16,14 +11,14 @@ class DrawImage(core.DataViewComponent):
         self.margin = 0
         self.setSize(200, 200)
         self.image = None
-        
+
     def tick(self, t):
         try:
             self.image = self.data.get(start=self.view.current_tick, count=1)[0][0]
         except Exception,e:
             print "error in get",e
             return
-                       
+
     def paintComponent(self, g):
         core.DataViewComponent.paintComponent(self, g)
 

--- a/simulator-ui/python/timeview/components/function.py
+++ b/simulator-ui/python/timeview/components/function.py
@@ -1,17 +1,13 @@
 import core
 
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
-from java.util import Hashtable
+import java
+from javax.swing import (
+    JCheckBoxMenuItem, JFileChooser, JLabel, JMenuItem, JOptionPane,
+    JPopupMenu, JSlider, Timer)
+from java.awt import Color, Font
+from java.awt.event import ComponentListener
 
 import random
-
-from math import floor
-from math import ceil
-
-import java
 
 
 class FunctionControl(core.DataViewComponent, ComponentListener):

--- a/simulator-ui/python/timeview/components/graph.py
+++ b/simulator-ui/python/timeview/components/graph.py
@@ -1,10 +1,8 @@
 import core
-import neuronmap
 
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
+from javax.swing import (
+    JCheckBoxMenuItem, JMenu, JMenuItem, JOptionPane, JPopupMenu)
+from java.awt import Color
 
 from math import sqrt
 from math import log

--- a/simulator-ui/python/timeview/components/grid.py
+++ b/simulator-ui/python/timeview/components/grid.py
@@ -1,10 +1,7 @@
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
+from javax.swing import JCheckBoxMenuItem, JMenuItem, JOptionPane, JPopupMenu
+from java.awt import Color
 
 import core
-import neuronmap
 import clicker
 
 from math import sqrt

--- a/simulator-ui/python/timeview/components/hrrgraph.py
+++ b/simulator-ui/python/timeview/components/hrrgraph.py
@@ -2,13 +2,11 @@ import core
 import graph
 import hrr
 
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
+from javax.swing import JCheckBoxMenuItem, JMenuItem, JOptionPane
+from java.awt import Color, Font
+
 import math
 import numeric
-
 
 class HRRGraph(graph.Graph):
     def __init__(self, view, name, func, args=(), filter=True, ylimits=(-1.0, 1.0), label=None, nodeid=None):

--- a/simulator-ui/python/timeview/components/item.py
+++ b/simulator-ui/python/timeview/components/item.py
@@ -1,9 +1,7 @@
 import core
 
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
+from javax.swing import JMenu, JMenuItem, JPopupMenu
+from java.awt import Color, Font
 
 
 class Item(core.DataViewComponent):

--- a/simulator-ui/python/timeview/components/preferred.py
+++ b/simulator-ui/python/timeview/components/preferred.py
@@ -1,7 +1,4 @@
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
+from java.awt import Color
 import java
 
 import core

--- a/simulator-ui/python/timeview/components/spike_line_overlay.py
+++ b/simulator-ui/python/timeview/components/spike_line_overlay.py
@@ -1,13 +1,7 @@
 import core
 
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
-
-from math import sqrt
-from math import log
-from math import ceil
+from javax.swing import ButtonGroup, JMenu, JPopupMenu, JRadioButtonMenuItem
+from java.awt import Color
 
 
 def safe_get_index(x, i):

--- a/simulator-ui/python/timeview/components/spike_raster.py
+++ b/simulator-ui/python/timeview/components/spike_raster.py
@@ -1,9 +1,7 @@
 import core
 
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
+from javax.swing import JCheckBoxMenuItem, JPopupMenu
+from java.awt import Color
 
 from math import sqrt
 import clicker

--- a/simulator-ui/python/timeview/components/text_list.py
+++ b/simulator-ui/python/timeview/components/text_list.py
@@ -1,10 +1,7 @@
 import core
-from java.awt import Color
 
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
+from javax.swing import JCheckBoxMenuItem, JPopupMenu
+from java.awt import Color
 
 
 class TextList(core.DataViewComponent):

--- a/simulator-ui/python/timeview/components/timecontrol.py
+++ b/simulator-ui/python/timeview/components/timecontrol.py
@@ -1,9 +1,11 @@
 import java
 import javax
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
+from javax.swing import (
+    ImageIcon, JButton, JComboBox, JFileChooser, JFrame, JLabel, JPanel,
+    JSlider, JSpinner, SpinnerNumberModel)
+from javax.swing.event import ChangeListener
+from java.awt import BorderLayout, Color, RenderingHints
+from java.awt.event import ActionListener
 
 from ca.nengo.model import SimulationMode
 
@@ -74,11 +76,11 @@ class TimeControl(JPanel, ChangeListener, ActionListener):
         pdf.maximumSize = pdf.preferredSize
         configPanel.add(pdf)
 
-        data = JPanel(layout=BorderLayout(), opaque=False)
-        data.add(JButton(Icon.data, rolloverIcon=ShadedIcon.data, toolTipText='examine data', actionPerformed=self.show_data, borderPainted=False, focusPainted=False, contentAreaFilled=False))
-        data.add(JLabel('data', horizontalAlignment=javax.swing.SwingConstants.CENTER), BorderLayout.NORTH)
-        data.maximumSize = data.preferredSize
-        configPanel.add(data)
+        self.data = JPanel(layout=BorderLayout(), opaque=False)
+        self.data.add(JButton(Icon.data, rolloverIcon=ShadedIcon.data, toolTipText='examine data', actionPerformed=self.show_data, borderPainted=False, focusPainted=False, contentAreaFilled=False))
+        self.data.add(JLabel('data', horizontalAlignment=javax.swing.SwingConstants.CENTER), BorderLayout.NORTH)
+        self.data.maximumSize = self.data.preferredSize
+        configPanel.add(self.data)
 
         mode = JPanel(layout=BorderLayout(), opaque=False)
         cb = JComboBox(['default', 'rate', 'direct'])
@@ -161,7 +163,7 @@ class TimeControl(JPanel, ChangeListener, ActionListener):
     def show_data(self, event):
         frame = JFrame('%s Data' % self.view.network.name)
         frame.visible = True
-        frame.add(data.DataPanel(self.view))
+        frame.add(self.data.DataPanel(self.view))
         frame.size = (500, 600)
 
     def forward_one_frame(self, event):
@@ -291,14 +293,14 @@ class TimeControl(JPanel, ChangeListener, ActionListener):
 
             cb.addTemplate(tp, 20, 0)
             doc.close()
-            
+
     class RoundedBorder(javax.swing.border.AbstractBorder):
         def __init__(self):
             self.color = Color(0.7, 0.7, 0.7)
-    
+
         def getBorderInsets(self, component):
             return java.awt.Insets(5, 5, 5, 5)
-    
+
         def paintBorder(self, c, g, x, y, width, height):
             g.color = self.color
             g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)

--- a/simulator-ui/python/timeview/components/vector_grid.py
+++ b/simulator-ui/python/timeview/components/vector_grid.py
@@ -1,7 +1,4 @@
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
+from java.awt import Color
 
 import core
 

--- a/simulator-ui/python/timeview/components/view3d.py
+++ b/simulator-ui/python/timeview/components/view3d.py
@@ -1,10 +1,9 @@
 import core
 
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
-import java
+from java.awt import Color
+from java.awt.event import ComponentListener, KeyEvent, KeyListener, InputEvent
+
+from com.threed.jpct import FrameBuffer, SimpleVector
 
 
 class View3D(core.DataViewComponent, ComponentListener, KeyListener):
@@ -22,7 +21,6 @@ class View3D(core.DataViewComponent, ComponentListener, KeyListener):
         self.initialize()
 
     def initialize(self):
-        from com.threed.jpct import FrameBuffer
         self.buffer = FrameBuffer(self.width, self.height, FrameBuffer.SAMPLINGMODE_NORMAL)
 
     def componentHidden(self, event):
@@ -64,7 +62,7 @@ class View3D(core.DataViewComponent, ComponentListener, KeyListener):
             self.mouse_pressed_y = event.y
             #java.lang.System.out.println("event %s "%(event))
             if event.modifiersEx & InputEvent.BUTTON3_DOWN_MASK:
-                from com.threed.jpct import SimpleVector
+
                 camera.rotateCameraAxis(SimpleVector(-dy, dx, 0), 0.003)
                 #camera.align(self.view.watcher.objects[self.name]._simulator.model.room)
                 #camera.setOrientation(camera.getDirection(),SimpleVector(0,0,1))

--- a/simulator-ui/python/timeview/components/viewpanel.py
+++ b/simulator-ui/python/timeview/components/viewpanel.py
@@ -1,15 +1,14 @@
 import java
 import javax
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
+from javax.swing import JPanel
+from java.awt import Color, RenderingHints
 
 import math
 
 from timeview.components import core
 
 from ca.nengo.model.impl import NetworkImpl
+
 
 class ViewPanel(JPanel):
     def __init__(self, network):
@@ -71,15 +70,15 @@ class ViewPanel(JPanel):
             self.paintProjection(oname, tname, g)
 
             # Check to see if the termination or origin is wrapped. If it is, then use that,
-            # otherwise, just use the termination / origin itself. 
+            # otherwise, just use the termination / origin itself.
             # Note: This may or may not have unintended consequences when checking what object
-            #       the termination / origin is connected to (see next code block - 
+            #       the termination / origin is connected to (see next code block -
             #       ... isinstance(termination.node, NetworkImpl) ...)
             if hasattr(termination, 'wrappedTermination' ):
                 termination = termination.wrappedTermination
             if hasattr(origin, 'wrappedOrigin' ):
                 origin = origin.wrappedOrigin
-    
+
             if isinstance(termination.node, NetworkImpl):
                 self.paintProjection(oname, tname + ':' + termination.node.name, g)
                 if isinstance(origin.node, NetworkImpl):
@@ -99,7 +98,7 @@ class ViewPanel(JPanel):
         g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
 
         self.paintProjections(self.network, g)
-        
+
     def tick(self, t):
         for c in self.getComponents():
             if isinstance(c, core.DataViewComponent):

--- a/simulator-ui/python/timeview/components/xyplot.py
+++ b/simulator-ui/python/timeview/components/xyplot.py
@@ -1,15 +1,11 @@
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
-import java
+from javax.swing import (ButtonGroup, JCheckBoxMenuItem, JMenu, JPopupMenu,
+                         JRadioButtonMenuItem, Timer)
+from java.awt import Color
 
 import core
 from graph import round
 
-from math import sqrt
-from math import log
-from math import ceil
+from math import ceil, log
 
 
 class XYPlot(core.DataViewComponent):

--- a/simulator-ui/python/timeview/data.py
+++ b/simulator-ui/python/timeview/data.py
@@ -1,11 +1,11 @@
 import java
-import javax
-from javax.swing import *
+from javax.swing import (
+    JButton, JCheckBoxMenuItem, JFileChooser, JLabel, JPanel, JPopupMenu,
+    JScrollPane, JSpinner, JTable, SpinnerNumberModel)
 from javax.swing.table import DefaultTableModel
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
-from java.io import *
+from java.awt import BorderLayout, Color
+from java.awt.event import MouseEvent, MouseListener
+from java.io import BufferedWriter, File, FileWriter
 from javax.swing.filechooser import FileFilter
 
 import view
@@ -20,18 +20,19 @@ class DataPanel(JPanel,MouseListener):
     def __init__(self,view):
         JPanel.__init__(self)
         self.view=view
-        self.background=Color.white        self.layout=BorderLayout()
+        self.background=Color.white
+        self.layout=BorderLayout()
 
         self.popup=JPopupMenu()
         self.popup_items={}
 
         self.add(self.make_controls(),BorderLayout.SOUTH)
-        
+
         data,title=self.extract_data()
         self.table=JTable(DefaultTableModel(data,title))
-        
+
         scroll=JScrollPane(self.table)
-        self.add(scroll)        
+        self.add(scroll)
 
         scroll.addMouseListener(self)
         self.table.tableHeader.addMouseListener(self)
@@ -40,9 +41,9 @@ class DataPanel(JPanel,MouseListener):
         self.fileChooser=JFileChooser()
         self.fileChooser.setFileFilter(CSVFilter())
         self.fileChooser.setSelectedFile(File('%s.csv'%self.view.network.name))
-        
-        
-        
+
+
+
     def make_controls(self):
         panel=JPanel(background=self.background)
         panel.add(JButton(view.Icon.refresh,actionPerformed=self.refresh,rolloverIcon=view.ShadedIcon.refresh,toolTipText='refresh',borderPainted=False,focusPainted=False,contentAreaFilled=False))
@@ -64,26 +65,26 @@ class DataPanel(JPanel,MouseListener):
         panel.add(JButton(view.Icon.save,actionPerformed=self.save,rolloverIcon=view.ShadedIcon.save,toolTipText='save',borderPainted=False,focusPainted=False,contentAreaFilled=False))
 
         return panel
-        
+
     def extract_data(self):
         pause_state=self.view.paused
         self.view.paused=True
-        
+
         while self.view.simulating:
             java.lang.Thread.sleep(10)
-    
+
         tau=float(self.filter.value)
         dt=self.view.dt
         if tau<dt: dt_tau=None
         else: dt_tau=dt/tau
-        
+
         decimals=int(self.decimals.value)
         format='%%1.%df'%decimals
-    
+
         start_index=max(0,self.view.timelog.tick_count-self.view.timelog.tick_limit+1)
         count=min(self.view.timelog.tick_limit,self.view.timelog.tick_count)
         start_time=start_index*self.view.dt
-        
+
         data=None
         title=['t']
         keys = self.view.watcher.active.keys()
@@ -91,7 +92,7 @@ class DataPanel(JPanel,MouseListener):
         for key in keys:
             watch = self.view.watcher.active[key]
             name,func,args=key
-            
+
             code='%s.%s%s'%(name,func.__name__,args)
             if code not in self.popup_items:
                 state=True
@@ -99,17 +100,17 @@ class DataPanel(JPanel,MouseListener):
                 if 'voltage' in func.__name__: state=False
                 self.popup_items[code]=JCheckBoxMenuItem(code,state,stateChanged=self.refresh)
                 self.popup.add(self.popup_items[code])
-            
+
             if self.popup_items[code].state is False: continue
-                
+
             d=watch.get(dt_tau=dt_tau,start=start_index,count=count)
             n=len(watch.get_first())
             if data is None:
                 data=[]
-                while len(data)<len(d): 
+                while len(data)<len(d):
                     data.append(['%0.4f'%(start_time+(len(data)+0)*self.view.dt)])
-            
-            
+
+
             for i in range(n):
                 title.append('%s[%d]'%(code,i))
                 for j in range(len(data)):
@@ -117,38 +118,37 @@ class DataPanel(JPanel,MouseListener):
                     if dd is None: data[j].append('')
                     else: data[j].append(format%dd[i])
 
-        self.view.paused=pause_state            
+        self.view.paused=pause_state
         return data,title
-        
-        
+
+
     def save(self,event=None):
         if self.fileChooser.showSaveDialog(self)==JFileChooser.APPROVE_OPTION:
             f=self.fileChooser.getSelectedFile()
             writer=BufferedWriter(FileWriter(f))
-            
+
             data,title=self.extract_data()
             title=[t.replace(',',' ') for t in title]
             writer.write(','.join(title)+'\n')
             for row in data:
                 writer.write(','.join(row)+'\n')
-            writer.close()    
-        
+            writer.close()
+
     def refresh(self,event=None):
         data,title=self.extract_data()
         self.table.model.setDataVector(data,title)
-        
+
         
     def mouseClicked(self, event):     
         if event.button==MouseEvent.BUTTON3 or (event.button==MouseEvent.BUTTON1 and event.isControlDown()):
             if self.popup is not None:
-                self.popup.show(event.source,event.x-5,event.y-5)   
+                self.popup.show(event.source,event.x-5,event.y-5)
             
     def mouseEntered(self, event):
         pass
     def mouseExited(self, event):        
         pass
-    def mousePressed(self, event):  
+    def mousePressed(self, event):
         pass
     def mouseReleased(self, event):        
         pass
-    

--- a/simulator-ui/python/timeview/watches/encodermapwatch.py
+++ b/simulator-ui/python/timeview/watches/encodermapwatch.py
@@ -1,9 +1,4 @@
-import nef
-
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
-import java
+from java.awt import Color
 
 import timeview.components.core as core
 import timeview.view
@@ -12,7 +7,7 @@ from timeview.watches import watchtemplate
 #this is here to provide the functionality of a global variable without cluttering the global namespace
 class EncoderMapWatchConfig:
     config={}
-    
+
     @classmethod
     def define(cls,obj,func,minx=-1,maxx=1,miny=-1,maxy=1,min_rate=0,max_rate=0.2,size=0.05):
         cls.config[obj]=(func,minx,maxx,miny,maxy,min_rate,max_rate,size)
@@ -32,11 +27,11 @@ class EncoderMap(core.DataViewComponent):
         self.data=self.view.watcher.watch(name,func,args=args)
         self.margin=10
         self.min=min
-        self.max=max        
+        self.max=max
         self.setSize(200,200)
         self.config=config
         self.encoders=encoders
-        
+
     def paintComponent(self,g):
         core.DataViewComponent.paintComponent(self,g)
 
@@ -44,34 +39,33 @@ class EncoderMap(core.DataViewComponent):
         y0=self.label_offset
         g.color=Color(0.8,0.8,0.8)
         g.fillRect(int(x0)-1,int(y0)-1,int(self.size.width)+1,int(self.size.height-self.label_offset)+1)
-        
-        
+
+
         dt_tau=None
         if self.view.tau_filter>0:
             dt_tau=self.view.dt/self.view.tau_filter
-        try:    
+        try:
             data=self.data.get(start=self.view.current_tick,count=1,dt_tau=dt_tau)[0]
         except:
             return
-        if data is None: 
+        if data is None:
             return
-        
+
         func,minx,maxx,miny,maxy,min_rate,max_rate,size=self.config
         size=size*min(self.size.width,self.size.height)
-                
+
         xscale=float(self.size.width-self.margin*2)/(maxx-minx)
         yscale=float(self.size.height-self.label_offset-self.margin*2)/(maxy-miny)
         for i,encoder in enumerate(self.encoders):
-        
+
             c=(float(data[i])-min_rate)/(max_rate-min_rate)
             if c>1.0: c=1.0
             if c<0.0: c=0.0
             g.color=Color(c,c,c)
-            
+
             x,y=func(encoder)
             x=xscale*(x-minx)+self.margin
             y=yscale*(y-miny)+self.margin
-            
-            
+
+
             g.fillRect(int(x-size/2),self.size.height-int(y-size/2),int(size),int(size))
-                   

--- a/simulator-ui/python/timeview/watches/funcrepwatch.py
+++ b/simulator-ui/python/timeview/watches/funcrepwatch.py
@@ -1,18 +1,13 @@
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
-import java
-from numeric import array, dot, reshape, ones, transpose, concatenate, floor, zeros, repeat
+from java.awt import Color
 
 import timeview.components.core as core
-import timeview.view
 from timeview.watches import watchtemplate
 
 class FuncRepWatch(watchtemplate.WatchTemplate):
     def check(self,obj):
         return hasattr(obj, 'getMetadata') and obj.getMetadata('FuncRepWatch') is not None
     def value(self,obj):
-        return obj.getOrigin('X').getValues().getValues()    
+        return obj.getOrigin('X').getValues().getValues()
     def views(self,obj):
         basis, label, minx, maxx, miny, maxy = obj.getMetadata('FuncRepWatch')
         return [(label,FunctionRepresentation,dict(func=self.value,label=obj.name,
@@ -42,27 +37,27 @@ class FunctionRepresentation(core.DataViewComponent):
 
         self.max = 0.0001
         self.min = -0.0001
-            
+
     def paintComponent(self,g):
-                
+
         core.DataViewComponent.paintComponent(self,g)
 
         width=self.size.width-self.border_left-self.border_right
         height=self.size.height-self.border_top-self.border_bottom-self.label_offset
-            
+
         if width<2: return
 
         dt_tau=None
         if self.view.tau_filter>0:
             dt_tau=self.view.dt/self.view.tau_filter
-        try:    
+        try:
             data=self.data.get(start=self.view.current_tick,count=1,dt_tau=dt_tau)[0]
         except:
             return
-        
+
         g.color=Color(0.8,0.8,0.8)
         g.drawRect(self.border_left,self.border_top+self.label_offset,width,height)
-        
+
         g.color=Color.black
         txt='%4g'%self.maxx
         bounds=g.font.getStringBounds(txt,g.fontRenderContext)
@@ -76,7 +71,7 @@ class FunctionRepresentation(core.DataViewComponent):
         g.drawString('%6g'%self.miny,0,self.size.height-self.border_bottom)
 
         g.color=Color.black
-        
+
         pdftemplate=getattr(self.view.area,'pdftemplate',None)
         if pdftemplate is not None:
             pdf,scale=pdftemplate
@@ -90,7 +85,7 @@ class FunctionRepresentation(core.DataViewComponent):
                 x=self.minx+i*dx
                 value=sum([self.basis(j,x)*d for j,d in enumerate(data)])
                 y=float((value-self.miny)*height/(self.maxy-self.miny))
-                
+
                 xx=self.border_left+i/float(steps)
                 yy=self.height-self.border_bottom-y
 
@@ -99,9 +94,9 @@ class FunctionRepresentation(core.DataViewComponent):
                 else:
                     if 0<y<height:
                         pdf.lineTo((self.x+xx)*scale,800-(self.y+yy)*scale)
-            pdf.setRGBColorStroke(g.color.red,g.color.green,g.color.blue)        
-            pdf.stroke()        
-        else:                
+            pdf.setRGBColorStroke(g.color.red,g.color.green,g.color.blue)
+            pdf.stroke()
+        else:
             dx=float(self.maxx-self.minx)/(width-1)
             px,py=None,None
             for i in range(width):
@@ -116,4 +111,3 @@ class FunctionRepresentation(core.DataViewComponent):
                 if px is not None and self.miny<value<self.maxy:
                     g.drawLine(px,py,xx,yy)
                 px,py=xx,yy
-

--- a/simulator-ui/python/timeview/watches/textwatch.py
+++ b/simulator-ui/python/timeview/watches/textwatch.py
@@ -1,12 +1,8 @@
-from javax.swing import *
-from javax.swing.event import *
-from java.awt import *
+from javax.swing import JLabel, JMenuItem, JPopupMenu
+from java.awt import Font
 import timeview.components.core as core
-import timeview.view
 from timeview.watches import watchtemplate
 from timeview.text import TextNode
-import java
-import javax
 
 class TextWatch(watchtemplate.WatchTemplate):
     def check(self,obj):
@@ -15,7 +11,7 @@ class TextWatch(watchtemplate.WatchTemplate):
         return obj.current_text()
     def views(self,obj):
         return [('text',TextView,dict(func=self.text,label=obj.name)),
-               ]    
+               ]
 
 class TextView(core.DataViewComponent):
     def __init__(self,view,name,func,args=(),label=None):
@@ -25,16 +21,16 @@ class TextView(core.DataViewComponent):
         self.func=func
         self.show_label=False
         self.update_label()
-        self.data=self.view.watcher.watch(name,func,args=args)        
+        self.data=self.view.watcher.watch(name,func,args=args)
         self.text_label=JLabel('',verticalAlignment=JLabel.CENTER,horizontalAlignment=JLabel.CENTER)
         self.text_label.font=Font('SansSerif',Font.BOLD,12)
         self.font_size=12
         self.add(self.text_label)
 
-        self.popup.add(JPopupMenu.Separator())        
+        self.popup.add(JPopupMenu.Separator())
         self.popup.add(JMenuItem('larger',actionPerformed=self.increase_font))
         self.popup.add(JMenuItem('smaller',actionPerformed=self.decrease_font))
-        
+
     def increase_font(self,event):
         self.font_size+=2
         self.text_label.font=Font('SansSerif',Font.BOLD,self.font_size)
@@ -42,26 +38,22 @@ class TextView(core.DataViewComponent):
         if self.font_size<7: return
         self.font_size-=2
         self.text_label.font=Font('SansSerif',Font.BOLD,self.font_size)
-            
-        
+
+
     def paintComponent(self,g):
-        core.DataViewComponent.paintComponent(self,g)        
+        core.DataViewComponent.paintComponent(self,g)
         data=self.data.get(start=self.view.current_tick,count=1)[0]
         self.text_label.setSize(self.width,self.height-self.label_offset)
         self.text_label.setLocation(0,self.label_offset)
         self.text_label.text=data
 
-        
+
     def save(self):
         info = core.DataViewComponent.save(self)
         info['font_size']=self.font_size
         return info
-    
+
     def restore(self,d):
         core.DataViewComponent.restore(self,d)
         self.font_size=d.get('font_size',12)
         self.text_label.font=Font('SansSerif',Font.BOLD,self.font_size)
-        
-
-
-     

--- a/simulator-ui/python/timeview/watches/tuningcurvewatch.py
+++ b/simulator-ui/python/timeview/watches/tuningcurvewatch.py
@@ -1,15 +1,8 @@
-from javax.swing.event import *
-from java.awt import *
-from java.awt.event import *
-import java
-
 from ca.nengo.model.nef import NEFEnsemble
 from ca.nengo.model import SimulationMode
 
-import timeview.components.core as core
 from timeview.components import Graph
 from timeview.watches import watchtemplate
-import timeview.view
 import math
 
 class TuningCurveWatch(watchtemplate.WatchTemplate):
@@ -37,7 +30,7 @@ class TuningCurveWatch(watchtemplate.WatchTemplate):
                     elif obj.dimension==2:
                         theta=xx*math.pi
                         input=math.sin(theta)*encoders[i][0]+math.cos(theta)*encoders[i][1]
-                    n.radialInput=input    
+                    n.radialInput=input
                     n.run(0,0)
                     output=n.getOrigin('AXON').getValues().getValues()[0]
                     rate.append(output)
@@ -56,17 +49,11 @@ class TuningCurveWatch(watchtemplate.WatchTemplate):
         if obj.dimension==1:
             labels[0]='%4g'%(-obj.radii[0])
             labels[pts*2]='%4g'%(obj.radii[0])
-        elif obj.dimension==2:    
+        elif obj.dimension==2:
             labels[0]='-180'
             labels[pts/2]='-90'
             labels[3*pts/2]='90'
             labels[pts*2]='180'
-        
+
         return [('tuning curves',Graph,
                  dict(func=None,label=obj.name,data=makedata,x_labels=labels,show_negative=False))]
-
-
-        
-        
-    
-    

--- a/simulator-ui/python/toolbar.py
+++ b/simulator-ui/python/toolbar.py
@@ -1,19 +1,17 @@
 import java
-from java.awt import *
-from javax.swing import *
+from java.awt import Color
+from javax.swing import (
+    AbstractButton, Box, ImageIcon, JButton, JLabel, JToolBar)
 
 import ca.nengo
-import sys
-
-import template
-
-SelectionHandler = ca.nengo.ui.lib.world.handlers.SelectionHandler
 
 from ca.nengo.math.impl import WeightedCostApproximator
 from ca.nengo.util.impl import NEFGPUInterface, NodeThreadPool
 from ca.nengo.ui.configurable.panels import BooleanPanel, IntegerPanel
-from ca.nengo.ui.configurable.descriptors import *
-from ca.nengo.ui.configurable import *
+from ca.nengo.ui.configurable.descriptors import PBoolean, PInt
+from ca.nengo.ui.configurable import (
+    ConfigException, ConfigSchemaImpl, IConfigurable)
+from ca.nengo.ui.lib.world.handlers import SelectionHandler
 
 
 class GpuCountPanel(IntegerPanel):
@@ -68,9 +66,6 @@ class PGpuUse(PBoolean):
 
     def createInputPanel(self):
         return GpuUsePanel(self)
-
-
-from ca.nengo.ui.configurable import ConfigException
 
 
 class ParallelizationConfiguration(IConfigurable):
@@ -129,12 +124,12 @@ class ParallelizationConfiguration(IConfigurable):
 
 def make_button(icon, func, tip, **args):
     return JButton(
-        icon=ImageIcon('python/images/%s.png' % icon), 
+        icon=ImageIcon('python/images/%s.png' % icon),
         rolloverIcon=ImageIcon('python/images/%s-pressed.png' % icon),
         actionPerformed=func, toolTipText=tip,
-        borderPainted=False, focusPainted=False, 
+        borderPainted=False, focusPainted=False,
         contentAreaFilled=False, margin=java.awt.Insets(0, 0, 0, 0),
-        verticalTextPosition=AbstractButton.BOTTOM, 
+        verticalTextPosition=AbstractButton.BOTTOM,
         horizontalTextPosition=AbstractButton.CENTER, **args)
 
 def make_label_button(text, func, tip, **args):
@@ -226,7 +221,7 @@ class ToolBar(
             if net is not None and hasattr(net, 'getViewer'):
                 viewer = net.getViewer()
 
-        if (viewer is not None and 
+        if (viewer is not None and
             (viewer.isDestroyed() or
              not isinstance(viewer, ca.nengo.ui.models.viewers.NetworkViewer))):
             return None


### PR DESCRIPTION
We keep having an issue with new versions of Java/Jython in which `import *` no longer imports everything we think it does. This should future-proof us, but not relying on `import *`.