### PR TITLE
Import template in startup-ui.py

### DIFF
--- a/simulator-ui/python/startup_ui.py
+++ b/simulator-ui/python/startup_ui.py
@@ -3,4 +3,5 @@ the graphical front-end to Nengo."""
 
 execfile('python/startup_common.py')
 import toolbar
+import template
 __nengo_ui__ = True


### PR DESCRIPTION
This fixes master, after merging the `import *` stuff from last night. Basically, we weren't importing `template` any more after my changes (I removed import statements we weren't using that other branch). But I guess template was being imported in some other .py file, which was actually doing stuff, but it probably should not have been. It should only be done in startup-ui.py, so now it is. Really, these kinds of after-effects should not happen as a result of import (it should be explicit), but there's a lot of refactoring that should happen in here. Anyway, Nengo runs properly for me now.